### PR TITLE
Fix candidates schema

### DIFF
--- a/tap_lever/schemas/candidates.json
+++ b/tap_lever/schemas/candidates.json
@@ -72,12 +72,11 @@
       "type": "string"
     },
     "tags": {
-      "type": "array",
-      "items": {}
+      "items": {},
       "type": [
         "array",
         "null"
-      ],
+      ]
     },
     "sources": {
       "type": "array",

--- a/tap_lever/schemas/candidates.json
+++ b/tap_lever/schemas/candidates.json
@@ -74,6 +74,10 @@
     "tags": {
       "type": "array",
       "items": {}
+      "type": [
+        "array",
+        "null"
+      ],
     },
     "sources": {
       "type": "array",


### PR DESCRIPTION
This PR fixes an `Error during transform` for `tags` in the `candidates` stream.

