### PR TITLE
Allow `owner` to be null

### DIFF
--- a/tap_lever/schemas/candidates.json
+++ b/tap_lever/schemas/candidates.json
@@ -69,7 +69,7 @@
       "items": {}
     },
     "owner": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "tags": {
       "items": {},


### PR DESCRIPTION
# Description of change
This PR fixes another transform error for the `candidates` stream

# Manual QA steps
 - Validated json with `jq`
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
