### PR TITLE
fix candidates schema; fix params bug; transformer

### DIFF
--- a/tap_lever/schemas/candidates.json
+++ b/tap_lever/schemas/candidates.json
@@ -10,6 +10,12 @@
     "headline": {
       "type": "string"
     },
+    "contact": {
+      "type": ["null", "string", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
     "emails": {
       "type": "array",
       "items": {

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -29,6 +29,8 @@ class BaseStream(base):
         if _next:
              params["offset"] = _next
 
+        return params
+
     def sync_data(self):
         table = self.TABLE
 
@@ -72,11 +74,16 @@ class BaseStream(base):
         return all_resources
 
     def get_stream_data(self, result):
-        return [
-            self.transform_record(record)
-            for record in result
-        ]
+        metadata = {}
 
+        if self.catalog.metadata is not None:
+            metadata = singer.metadata.to_map(self.catalog.metadata)
+
+        with singer.Transformer() as tx:
+            return [
+                tx.transform(record, self.catalog.schema.to_dict(), metadata)
+                for record in result
+            ]
 
 class TimeRangeStream(BaseStream):
     RANGE_FIELD = 'updated_at'


### PR DESCRIPTION
The candidates schema is a string / array of strings.

A bug was appearing in the looks that looked like the following:

```
2019-11-12 17:58:29,182Z    tap - CRITICAL 'NoneType' object does not support item assignment
2019-11-12 17:58:29,183Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/tap_lever/streams/base.py", line 68, in sync_paginated
2019-11-12 17:58:29,183Z    tap -     params['offset'] = _next
```

I believe this is because the `get_params` function was returning `None`

The transformer is spammy, so only create one per page of records.