### PR TITLE
Add offers, users, and archived reasons streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ It:
 - Generates a catalog of available data in Lever
 - Extracts the following resources:
   - candidates
-  - postings
+  - archive resons
+  - applications
+  - offers
   - referrals
+  - postings
   - requisitions
   - sources
   - stages
+  - users
 
 ### Quick Start
 

--- a/tap_lever/config.py
+++ b/tap_lever/config.py
@@ -1,9 +1,9 @@
+import pytz
 import singer
-
 from dateutil.parser import parse
 
 LOGGER = singer.get_logger()  # noqa
 
 
 def get_config_start_date(config):
-    return parse(config.get('start_date'))
+    return parse(config.get("start_date")).replace(tzinfo=pytz.utc)

--- a/tap_lever/schemas/archive_reasons.json
+++ b/tap_lever/schemas/archive_reasons.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    }
+  }
+}

--- a/tap_lever/schemas/candidate_offers.json
+++ b/tap_lever/schemas/candidate_offers.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "creator": {
+      "type": ["string", "null"]
+    },
+    "status": {
+      "type": ["string", "null"]
+    },
+    "fields": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "properties": {
+          "text": {
+            "type": ["string", "null"]
+          },
+          "identifier": {
+            "type": ["string", "null"]
+          },
+          "value": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "signatures": {
+      "type": ["object", "null"],
+      "properties": {
+        "role": {
+          "type": ["string", "null"]
+        },
+        "name": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "firstOpenedAt": {
+          "type": ["integer", "null"]
+        },
+        "lastOpenedAt": {
+          "type": ["integer", "null"]
+        },
+        "signedAt": {
+          "type": ["integer", "null"]
+        },
+        "signed": {
+          "type": ["boolean", "null"]
+        }
+      }
+    },
+    "approvedAt": {
+      "type": ["integer", "null"]
+    },
+    "sentAt": {
+      "type": ["integer", "null"]
+    }
+  }
+}

--- a/tap_lever/schemas/users.json
+++ b/tap_lever/schemas/users.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": ["string", "null"]
+    },
+    "username": {
+      "type": ["string", "null"]
+    },
+    "email": {
+      "type": ["string", "null"]
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "deactivatedAt": {
+      "type": ["integer", "null"]
+    },
+    "accessRole": {
+      "type": ["string", "null"]
+    },
+    "photo": {
+      "type": ["string", "null"]
+    },
+    "externalDirectoryId": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -1,14 +1,16 @@
-from tap_lever.streams.candidates import CandidateStream
-from tap_lever.streams.referrals import CandidateReferralsStream
 from tap_lever.streams.applications import CandidateApplicationsStream
+from tap_lever.streams.candidates import CandidateStream
+from tap_lever.streams.offers import CandidateOffersStream
 from tap_lever.streams.postings import PostingsStream
+from tap_lever.streams.referrals import CandidateReferralsStream
 from tap_lever.streams.requisitions import RequisitionStream
 from tap_lever.streams.sources import SourcesStream
 from tap_lever.streams.stages import StagesStream
 
 AVAILABLE_STREAMS = [
-    CandidateStream,
+    CandidateStream,  # must sync first to fill CACHE
     CandidateApplicationsStream,
+    CandidateOffersStream,
     CandidateReferralsStream,
     PostingsStream,
     RequisitionStream,
@@ -17,11 +19,12 @@ AVAILABLE_STREAMS = [
 ]
 
 __all__ = [
-    'CandidateStream',
-    'CandidateApplicationsStream',
-    'CandidateReferralsStream',
-    'PostingsStream',
-    'RequisitionStream',
-    'SourcesStream',
-    'StagesStream',
+    "CandidateStream",
+    "CandidateApplicationsStream",
+    "CandidateOffersStream",
+    "CandidateReferralsStream",
+    "PostingsStream",
+    "RequisitionStream",
+    "SourcesStream",
+    "StagesStream",
 ]

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -7,6 +7,7 @@ from tap_lever.streams.referrals import CandidateReferralsStream
 from tap_lever.streams.requisitions import RequisitionStream
 from tap_lever.streams.sources import SourcesStream
 from tap_lever.streams.stages import StagesStream
+from tap_lever.streams.users import UsersStream
 
 AVAILABLE_STREAMS = [
     CandidateStream,  # must sync first to fill CACHE
@@ -18,6 +19,7 @@ AVAILABLE_STREAMS = [
     RequisitionStream,
     SourcesStream,
     StagesStream,
+    UsersStream,
 ]
 
 __all__ = [
@@ -30,4 +32,5 @@ __all__ = [
     "RequisitionStream",
     "SourcesStream",
     "StagesStream",
+    "UsersStream",
 ]

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -1,4 +1,5 @@
 from tap_lever.streams.applications import CandidateApplicationsStream
+from tap_lever.streams.archive_reasons import ArchiveReasonsStream
 from tap_lever.streams.candidates import CandidateStream
 from tap_lever.streams.offers import CandidateOffersStream
 from tap_lever.streams.postings import PostingsStream
@@ -9,6 +10,7 @@ from tap_lever.streams.stages import StagesStream
 
 AVAILABLE_STREAMS = [
     CandidateStream,  # must sync first to fill CACHE
+    ArchiveReasonsStream,
     CandidateApplicationsStream,
     CandidateOffersStream,
     CandidateReferralsStream,
@@ -20,6 +22,7 @@ AVAILABLE_STREAMS = [
 
 __all__ = [
     "CandidateStream",
+    "ArchiveReasonsStream",
     "CandidateApplicationsStream",
     "CandidateOffersStream",
     "CandidateReferralsStream",

--- a/tap_lever/streams/archive_reasons.py
+++ b/tap_lever/streams/archive_reasons.py
@@ -1,0 +1,13 @@
+import singer
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class ArchiveReasonsStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "archive_reasons"
+
+    @property
+    def path(self):
+        return "/archive_reasons"

--- a/tap_lever/streams/offers.py
+++ b/tap_lever/streams/offers.py
@@ -1,0 +1,31 @@
+import singer
+from tap_lever.streams import cache as stream_cache
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class CandidateOffersStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "candidate_offers"
+
+    @property
+    def path(self):
+        return "/candidates/{candidate_id}/offers"
+
+    def get_url(self, candidate):
+        _path = self.path.format(candidate_id=candidate)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        candidates = stream_cache.get("candidates")
+        LOGGER.info("Found {} candidates in cache".format(len(candidates)))
+
+        params = self.get_params(_next=None)
+        for i, candidate in enumerate(candidates):
+            LOGGER.info(
+                "Fetching offers for candidate {} of {}".format(i + 1, len(candidates))
+            )
+            candidate_id = candidate["id"]
+            url = self.get_url(candidate_id)
+            resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/users.py
+++ b/tap_lever/streams/users.py
@@ -1,0 +1,13 @@
+import singer
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class UsersStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "users"
+
+    @property
+    def path(self):
+        return "/users"


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)
Add offers, users, and archived reasons streams. It also makes the default `start_date` timezone aware.

# Manual QA steps

```
tap-lever -c config.json > catalog.json
# select candidates, candidate_offers, users, and archive_reasons in catalog. easy to do with:
# IMPORTANT: candidates must be selected for candidate_offers to work
singer-discover --input catalog.json --output catalog-selected.json
tap-lever -c config.json --catalog catalog-selected.json | target-stitch -n
``` 
# Risks
 - To keep things consistent, I implemented `candidate_offers` similarly to `candidate_referrals` and `candidate_applications`. However, based on the [docs](https://hire.lever.co/developer/documentation#candidates) it looks like `candidates` have been deprecated in favor of `opportunities`. Fixing this would mean changing all these streams to leverage opportunities instead, which might cause some data issues for those migrating.
 
# Rollback steps
 - revert this branch
