### PR TITLE
Opportunities migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ It:
 - Generates a catalog of available data in Lever
 - Extracts the following resources:
   - candidates
-  - postings
+  - archive resons
+  - applications
+  - offers
   - referrals
+  - postings
   - requisitions
   - sources
   - stages
+  - users
 
 ### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ It:
   - archive resons
   - applications
   - offers
+  - opportunities
   - referrals
+  - resumes
   - postings
   - requisitions
   - sources

--- a/tap_lever/config.py
+++ b/tap_lever/config.py
@@ -1,9 +1,9 @@
+import pytz
 import singer
-
 from dateutil.parser import parse
 
 LOGGER = singer.get_logger()  # noqa
 
 
 def get_config_start_date(config):
-    return parse(config.get('start_date'))
+    return parse(config.get("start_date")).replace(tzinfo=pytz.utc)

--- a/tap_lever/schemas/archive_reasons.json
+++ b/tap_lever/schemas/archive_reasons.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    }
+  }
+}

--- a/tap_lever/schemas/candidate_offers.json
+++ b/tap_lever/schemas/candidate_offers.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "creator": {
+      "type": ["string", "null"]
+    },
+    "status": {
+      "type": ["string", "null"]
+    },
+    "fields": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "properties": {
+          "text": {
+            "type": ["string", "null"]
+          },
+          "identifier": {
+            "type": ["string", "null"]
+          },
+          "value": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "signatures": {
+      "type": ["object", "null"],
+      "properties": {
+        "role": {
+          "type": ["string", "null"]
+        },
+        "name": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "firstOpenedAt": {
+          "type": ["integer", "null"]
+        },
+        "lastOpenedAt": {
+          "type": ["integer", "null"]
+        },
+        "signedAt": {
+          "type": ["integer", "null"]
+        },
+        "signed": {
+          "type": ["boolean", "null"]
+        }
+      }
+    },
+    "approvedAt": {
+      "type": ["integer", "null"]
+    },
+    "sentAt": {
+      "type": ["integer", "null"]
+    }
+  }
+}

--- a/tap_lever/schemas/candidate_resumes.json
+++ b/tap_lever/schemas/candidate_resumes.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "file": {
+      "type": ["object", "null"],
+      "properties": {}
+    },
+    "parsedData": {
+      "type": ["object", "null"],
+      "properties": {}
+    }
+  }
+}

--- a/tap_lever/schemas/candidates.json
+++ b/tap_lever/schemas/candidates.json
@@ -51,7 +51,14 @@
     },
     "archived": {
       "type": ["null", "object"],
-      "properties": {}
+      "properties": {
+        "archivedAt": {
+          "type": ["integer", "null"]
+        },
+        "reason": {
+          "type": ["string", "null"]
+        }
+      }
     },
     "tags": {
       "type": ["array", "null"],

--- a/tap_lever/schemas/opportunities.json
+++ b/tap_lever/schemas/opportunities.json
@@ -83,10 +83,6 @@
         "type": ["string", "null"]
       }
     },
-    "resume": {
-      "type": ["null", "object"],
-      "properties": {}
-    },
     "createdAt": {
       "type": ["integer", "null"]
     },

--- a/tap_lever/schemas/opportunities.json
+++ b/tap_lever/schemas/opportunities.json
@@ -51,7 +51,14 @@
     },
     "archived": {
       "type": ["null", "object"],
-      "properties": {}
+      "properties": {
+        "archivedAt": {
+          "type": ["integer", "null"]
+        },
+        "reason": {
+          "type": ["string", "null"]
+        }
+      }
     },
     "tags": {
       "type": ["array", "null"],

--- a/tap_lever/schemas/opportunity_applications.json
+++ b/tap_lever/schemas/opportunity_applications.json
@@ -1,0 +1,39 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "candidateId": {
+            "type": "string"
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "posting": {
+            "type": ["null", "string"]
+        },
+        "user": {
+            "type": ["null", "string"]
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "email": {
+            "type": ["null", "string"]
+        },
+        "createdAt": {
+            "type": ["null", "number"]
+        },
+        "phone": {},
+        "company": {},
+        "links": {},
+        "comments": {},
+        "resume": {},
+        "customQuestions": {},
+        "archived": {},
+        "postingHiringManager": {},
+        "postingOwner": {},
+        "requisitionForHire": {}
+    }
+}

--- a/tap_lever/schemas/opportunity_offers.json
+++ b/tap_lever/schemas/opportunity_offers.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "creator": {
+      "type": ["string", "null"]
+    },
+    "status": {
+      "type": ["string", "null"]
+    },
+    "fields": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "properties": {
+          "text": {
+            "type": ["string", "null"]
+          },
+          "identifier": {
+            "type": ["string", "null"]
+          },
+          "value": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "signatures": {
+      "type": ["object", "null"],
+      "properties": {
+        "role": {
+          "type": ["string", "null"]
+        },
+        "name": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "firstOpenedAt": {
+          "type": ["integer", "null"]
+        },
+        "lastOpenedAt": {
+          "type": ["integer", "null"]
+        },
+        "signedAt": {
+          "type": ["integer", "null"]
+        },
+        "signed": {
+          "type": ["boolean", "null"]
+        }
+      }
+    },
+    "approvedAt": {
+      "type": ["integer", "null"]
+    },
+    "sentAt": {
+      "type": ["integer", "null"]
+    }
+  }
+}

--- a/tap_lever/schemas/opportunity_referrals.json
+++ b/tap_lever/schemas/opportunity_referrals.json
@@ -1,0 +1,72 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "text": {
+            "type": ["null", "string"]
+        },
+        "instructions": {
+            "type": ["null", "string"]
+        },
+        "fields": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": ["null", "string"]
+                    },
+                    "text": {
+                        "type": ["null", "string"]
+                    },
+                    "description": {
+                        "type": ["null", "string"]
+                    },
+                    "required": {
+                        "type": ["null", "boolean"]
+                    },
+                    "value": {
+                        "type": ["null", "string"]
+                    },
+                    "prompt": {
+                        "type": ["null", "string"]
+                    },
+                    "options": {
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "text": {
+                                    "type": ["null", "string"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "baseTemplateId": {
+            "type": ["null", "string"]
+        },
+        "user": {
+            "type": ["null", "string"]
+        },
+        "referrer": {
+            "type": ["null", "string"]
+        },
+        "stage": {
+            "type": ["null", "string"]
+        },
+        "createdAt": {
+            "type": ["null", "integer"]
+        },
+        "completedAt": {
+            "type": ["null", "integer"]
+        }
+    }
+}

--- a/tap_lever/schemas/opportunity_resumes.json
+++ b/tap_lever/schemas/opportunity_resumes.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "file": {
+      "type": ["object", "null"],
+      "properties": {}
+    },
+    "parsedData": {
+      "type": ["object", "null"],
+      "properties": {}
+    }
+  }
+}

--- a/tap_lever/schemas/users.json
+++ b/tap_lever/schemas/users.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": ["string", "null"]
+    },
+    "username": {
+      "type": ["string", "null"]
+    },
+    "email": {
+      "type": ["string", "null"]
+    },
+    "createdAt": {
+      "type": ["integer", "null"]
+    },
+    "deactivatedAt": {
+      "type": ["integer", "null"]
+    },
+    "accessRole": {
+      "type": ["string", "null"]
+    },
+    "photo": {
+      "type": ["string", "null"]
+    },
+    "externalDirectoryId": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -1,14 +1,16 @@
-from tap_lever.streams.candidates import CandidateStream
-from tap_lever.streams.referrals import CandidateReferralsStream
 from tap_lever.streams.applications import CandidateApplicationsStream
+from tap_lever.streams.candidates import CandidateStream
+from tap_lever.streams.offers import CandidateOffersStream
 from tap_lever.streams.postings import PostingsStream
+from tap_lever.streams.referrals import CandidateReferralsStream
 from tap_lever.streams.requisitions import RequisitionStream
 from tap_lever.streams.sources import SourcesStream
 from tap_lever.streams.stages import StagesStream
 
 AVAILABLE_STREAMS = [
-    CandidateStream,
+    CandidateStream,  # must sync first to fill CACHE
     CandidateApplicationsStream,
+    CandidateOffersStream,
     CandidateReferralsStream,
     PostingsStream,
     RequisitionStream,
@@ -17,11 +19,12 @@ AVAILABLE_STREAMS = [
 ]
 
 __all__ = [
-    'CandidateStream',
-    'CandidateApplicationsStream',
-    'CandidateReferralsStream',
-    'PostingsStream',
-    'RequisitionStream',
-    'SourcesStream',
-    'StagesStream',
+    "CandidateStream",
+    "CandidateApplicationsStream",
+    "CandidateOffersStream",
+    "CandidateReferralsStream",
+    "PostingsStream",
+    "RequisitionStream",
+    "SourcesStream",
+    "StagesStream",
 ]

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -7,6 +7,7 @@ from tap_lever.streams.referrals import CandidateReferralsStream
 from tap_lever.streams.requisitions import RequisitionStream
 from tap_lever.streams.sources import SourcesStream
 from tap_lever.streams.stages import StagesStream
+from tap_lever.streams.users import UsersStream
 
 AVAILABLE_STREAMS = [
     CandidateStream,  # must sync first to fill CACHE
@@ -18,6 +19,7 @@ AVAILABLE_STREAMS = [
     RequisitionStream,
     SourcesStream,
     StagesStream,
+    UsersStream,
 ]
 
 __all__ = [
@@ -30,4 +32,5 @@ __all__ = [
     "RequisitionStream",
     "SourcesStream",
     "StagesStream",
+    "UsersStream",
 ]

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -1,9 +1,16 @@
-from tap_lever.streams.applications import CandidateApplicationsStream
+from tap_lever.streams.applications import (
+    CandidateApplicationsStream,
+    OpportunityApplicationsStream,
+)
 from tap_lever.streams.archive_reasons import ArchiveReasonsStream
 from tap_lever.streams.candidates import CandidateStream
-from tap_lever.streams.offers import CandidateOffersStream
+from tap_lever.streams.offers import CandidateOffersStream, OpportunityOffersStream
+from tap_lever.streams.opportunities import OpportunityStream
 from tap_lever.streams.postings import PostingsStream
-from tap_lever.streams.referrals import CandidateReferralsStream
+from tap_lever.streams.referrals import (
+    CandidateReferralsStream,
+    OpportunityReferralsStream,
+)
 from tap_lever.streams.requisitions import RequisitionStream
 from tap_lever.streams.sources import SourcesStream
 from tap_lever.streams.stages import StagesStream
@@ -11,10 +18,14 @@ from tap_lever.streams.users import UsersStream
 
 AVAILABLE_STREAMS = [
     CandidateStream,  # must sync first to fill CACHE
+    OpportunityStream,  # must sync first to fill CACHE
     ArchiveReasonsStream,
     CandidateApplicationsStream,
     CandidateOffersStream,
     CandidateReferralsStream,
+    OpportunityApplicationsStream,
+    OpportunityOffersStream,
+    OpportunityReferralsStream,
     PostingsStream,
     RequisitionStream,
     SourcesStream,
@@ -24,10 +35,14 @@ AVAILABLE_STREAMS = [
 
 __all__ = [
     "CandidateStream",
+    "OpportunityStream",
     "ArchiveReasonsStream",
     "CandidateApplicationsStream",
     "CandidateOffersStream",
     "CandidateReferralsStream",
+    "OpportunityApplicationsStream",
+    "OpportunityOffersStream",
+    "OpportunityReferralsStream",
     "PostingsStream",
     "RequisitionStream",
     "SourcesStream",

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -1,4 +1,5 @@
 from tap_lever.streams.applications import CandidateApplicationsStream
+from tap_lever.streams.archive_reasons import ArchiveReasonsStream
 from tap_lever.streams.candidates import CandidateStream
 from tap_lever.streams.offers import CandidateOffersStream
 from tap_lever.streams.postings import PostingsStream
@@ -9,6 +10,7 @@ from tap_lever.streams.stages import StagesStream
 
 AVAILABLE_STREAMS = [
     CandidateStream,  # must sync first to fill CACHE
+    ArchiveReasonsStream,
     CandidateApplicationsStream,
     CandidateOffersStream,
     CandidateReferralsStream,
@@ -20,6 +22,7 @@ AVAILABLE_STREAMS = [
 
 __all__ = [
     "CandidateStream",
+    "ArchiveReasonsStream",
     "CandidateApplicationsStream",
     "CandidateOffersStream",
     "CandidateReferralsStream",

--- a/tap_lever/streams/__init__.py
+++ b/tap_lever/streams/__init__.py
@@ -12,6 +12,7 @@ from tap_lever.streams.referrals import (
     OpportunityReferralsStream,
 )
 from tap_lever.streams.requisitions import RequisitionStream
+from tap_lever.streams.resumes import CandidateResumesStream, OpportunityResumesStream
 from tap_lever.streams.sources import SourcesStream
 from tap_lever.streams.stages import StagesStream
 from tap_lever.streams.users import UsersStream
@@ -23,9 +24,11 @@ AVAILABLE_STREAMS = [
     CandidateApplicationsStream,
     CandidateOffersStream,
     CandidateReferralsStream,
+    CandidateResumesStream,
     OpportunityApplicationsStream,
     OpportunityOffersStream,
     OpportunityReferralsStream,
+    OpportunityResumesStream,
     PostingsStream,
     RequisitionStream,
     SourcesStream,
@@ -40,9 +43,11 @@ __all__ = [
     "CandidateApplicationsStream",
     "CandidateOffersStream",
     "CandidateReferralsStream",
+    "CandidateResumesStream",
     "OpportunityApplicationsStream",
     "OpportunityOffersStream",
     "OpportunityReferralsStream",
+    "OpportunityResumesStream",
     "PostingsStream",
     "RequisitionStream",
     "SourcesStream",

--- a/tap_lever/streams/applications.py
+++ b/tap_lever/streams/applications.py
@@ -1,32 +1,65 @@
-from tap_lever.streams.base import BaseStream
-from tap_lever.streams import cache as stream_cache
-
 import singer
+from tap_lever.streams import cache as stream_cache
+from tap_lever.streams.base import BaseStream
 
 LOGGER = singer.get_logger()  # noqa
 
 
 class CandidateApplicationsStream(BaseStream):
-    API_METHOD = 'GET'
-    TABLE = 'candidate_applications'
+    API_METHOD = "GET"
+    TABLE = "candidate_applications"
 
     @property
     def path(self):
-        return '/candidates/{candidate_id}/applications'
+        return "/candidates/{candidate_id}/applications"
 
     def get_url(self, candidate):
         _path = self.path.format(candidate_id=candidate)
-        return 'https://api.lever.co/v1{}'.format(_path)
+        return "https://api.lever.co/v1{}".format(_path)
 
     def sync_data(self):
         table = self.TABLE
 
-        candidates = stream_cache.get('candidates')
+        candidates = stream_cache.get("candidates")
         LOGGER.info("Found {} candidates in cache".format(len(candidates)))
 
         params = self.get_params(_next=None)
         for i, candidate in enumerate(candidates):
-            LOGGER.info("Fetching referrals for candidate {} of {}".format(i + 1, len(candidates)))
-            candidate_id = candidate['id']
+            LOGGER.info(
+                "Fetching referrals for candidate {} of {}".format(
+                    i + 1, len(candidates)
+                )
+            )
+            candidate_id = candidate["id"]
             url = self.get_url(candidate_id)
+            resources = self.sync_paginated(url, params)
+
+
+class OpportunityApplicationsStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "opportunity_applications"
+
+    @property
+    def path(self):
+        return "/opportunities/{opportunity_id}/applications"
+
+    def get_url(self, opportunity):
+        _path = self.path.format(opportunity_id=opportunity)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        table = self.TABLE
+
+        opportunities = stream_cache.get("opportunities")
+        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
+
+        params = self.get_params(_next=None)
+        for i, opportunity in enumerate(opportunities):
+            LOGGER.info(
+                "Fetching referrals for opportunity {} of {}".format(
+                    i + 1, len(opportunities)
+                )
+            )
+            opportunity_id = opportunity["id"]
+            url = self.get_url(opportunity_id)
             resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/archive_reasons.py
+++ b/tap_lever/streams/archive_reasons.py
@@ -1,0 +1,13 @@
+import singer
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class ArchiveReasonsStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "archive_reasons"
+
+    @property
+    def path(self):
+        return "/archive_reasons"

--- a/tap_lever/streams/offers.py
+++ b/tap_lever/streams/offers.py
@@ -1,0 +1,31 @@
+import singer
+from tap_lever.streams import cache as stream_cache
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class CandidateOffersStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "candidate_offers"
+
+    @property
+    def path(self):
+        return "/candidates/{candidate_id}/offers"
+
+    def get_url(self, candidate):
+        _path = self.path.format(candidate_id=candidate)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        candidates = stream_cache.get("candidates")
+        LOGGER.info("Found {} candidates in cache".format(len(candidates)))
+
+        params = self.get_params(_next=None)
+        for i, candidate in enumerate(candidates):
+            LOGGER.info(
+                "Fetching offers for candidate {} of {}".format(i + 1, len(candidates))
+            )
+            candidate_id = candidate["id"]
+            url = self.get_url(candidate_id)
+            resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/offers.py
+++ b/tap_lever/streams/offers.py
@@ -29,3 +29,31 @@ class CandidateOffersStream(BaseStream):
             candidate_id = candidate["id"]
             url = self.get_url(candidate_id)
             resources = self.sync_paginated(url, params)
+
+
+class OpportunityOffersStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "opportunity_offers"
+
+    @property
+    def path(self):
+        return "/opportunities/{opportunity_id}/offers"
+
+    def get_url(self, opportunity):
+        _path = self.path.format(opportunity_id=opportunity)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        opportunities = stream_cache.get("opportunities")
+        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
+
+        params = self.get_params(_next=None)
+        for i, opportunity in enumerate(opportunities):
+            LOGGER.info(
+                "Fetching offers for opportunity {} of {}".format(
+                    i + 1, len(opportunities)
+                )
+            )
+            opportunity_id = opportunity["id"]
+            url = self.get_url(opportunity_id)
+            resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/opportunities.py
+++ b/tap_lever/streams/opportunities.py
@@ -1,0 +1,17 @@
+import singer
+from tap_lever.streams import cache as stream_cache
+from tap_lever.streams.base import TimeRangeStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class OpportunityStream(TimeRangeStream):
+    API_METHOD = "GET"
+    TABLE = "opportunities"
+    KEY_PROPERTIES = ["id"]
+
+    CACHE_RESULTS = True
+
+    @property
+    def path(self):
+        return "/opportunities"

--- a/tap_lever/streams/referrals.py
+++ b/tap_lever/streams/referrals.py
@@ -1,32 +1,65 @@
-from tap_lever.streams.base import BaseStream
-from tap_lever.streams import cache as stream_cache
-
 import singer
+from tap_lever.streams import cache as stream_cache
+from tap_lever.streams.base import BaseStream
 
 LOGGER = singer.get_logger()  # noqa
 
 
 class CandidateReferralsStream(BaseStream):
-    API_METHOD = 'GET'
-    TABLE = 'candidate_referrals'
+    API_METHOD = "GET"
+    TABLE = "candidate_referrals"
 
     @property
     def path(self):
-        return '/candidates/{candidate_id}/referrals'
+        return "/candidates/{candidate_id}/referrals"
 
     def get_url(self, candidate):
         _path = self.path.format(candidate_id=candidate)
-        return 'https://api.lever.co/v1{}'.format(_path)
+        return "https://api.lever.co/v1{}".format(_path)
 
     def sync_data(self):
         table = self.TABLE
 
-        candidates = stream_cache.get('candidates')
+        candidates = stream_cache.get("candidates")
         LOGGER.info("Found {} candidates in cache".format(len(candidates)))
 
         params = self.get_params(_next=None)
         for i, candidate in enumerate(candidates):
-            LOGGER.info("Fetching referrals for candidate {} of {}".format(i + 1, len(candidates)))
-            candidate_id = candidate['id']
+            LOGGER.info(
+                "Fetching referrals for candidate {} of {}".format(
+                    i + 1, len(candidates)
+                )
+            )
+            candidate_id = candidate["id"]
             url = self.get_url(candidate_id)
+            resources = self.sync_paginated(url, params)
+
+
+class OpportunityReferralsStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "opportunity_referrals"
+
+    @property
+    def path(self):
+        return "/opportunities/{opportunity_id}/referrals"
+
+    def get_url(self, opportunity):
+        _path = self.path.format(opportunity_id=opportunity)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        table = self.TABLE
+
+        opportunities = stream_cache.get("opportunities")
+        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
+
+        params = self.get_params(_next=None)
+        for i, opportunity in enumerate(opportunities):
+            LOGGER.info(
+                "Fetching referrals for opportunity {} of {}".format(
+                    i + 1, len(opportunities)
+                )
+            )
+            opportunity_id = opportunity["id"]
+            url = self.get_url(opportunity_id)
             resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/resumes.py
+++ b/tap_lever/streams/resumes.py
@@ -1,0 +1,60 @@
+import singer
+
+from tap_lever.streams import cache as stream_cache
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class CandidateResumesStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "candidate_resumes"
+
+    @property
+    def path(self):
+        return "/candidates/{candidate_id}/resumes"
+
+    def get_url(self, candidate):
+        _path = self.path.format(candidate_id=candidate)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        candidates = stream_cache.get("candidates")
+        LOGGER.info("Found {} candidates in cache".format(len(candidates)))
+
+        params = self.get_params(_next=None)
+        for i, candidate in enumerate(candidates):
+            LOGGER.info(
+                "Fetching resumes for candidate {} of {}".format(i + 1, len(candidates))
+            )
+            candidate_id = candidate["id"]
+            url = self.get_url(candidate_id)
+            resources = self.sync_paginated(url, params)
+
+
+class OpportunityResumesStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "opportunity_resumes"
+
+    @property
+    def path(self):
+        return "/opportunities/{opportunity_id}/resumes"
+
+    def get_url(self, opportunity):
+        _path = self.path.format(opportunity_id=opportunity)
+        return "https://api.lever.co/v1{}".format(_path)
+
+    def sync_data(self):
+        opportunities = stream_cache.get("opportunities")
+        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
+
+        params = self.get_params(_next=None)
+        for i, opportunity in enumerate(opportunities):
+            LOGGER.info(
+                "Fetching resumes for opportunity {} of {}".format(
+                    i + 1, len(opportunities)
+                )
+            )
+            opportunity_id = opportunity["id"]
+            url = self.get_url(opportunity_id)
+            resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/users.py
+++ b/tap_lever/streams/users.py
@@ -1,0 +1,13 @@
+import singer
+from tap_lever.streams.base import BaseStream
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class UsersStream(BaseStream):
+    API_METHOD = "GET"
+    TABLE = "users"
+
+    @property
+    def path(self):
+        return "/users"


### PR DESCRIPTION
# Description of change

Add Opportunities streams and migrate candidate_{offers,referrals,apllications} streams to opportunity_{offers,referrals,apllications} streams. The old candidate streams are maintained for backward compatibility but become deprecated and should be removed in the future.

# Rollback steps
 - revert this branch
