### PR TITLE
Fix exception when a candidate/opportunity does not have a resume

### DIFF
--- a/tap_lever/streams/resumes.py
+++ b/tap_lever/streams/resumes.py
@@ -28,8 +28,15 @@ class CandidateResumesStream(BaseStream):
             )
             candidate_id = candidate["id"]
             url = self.get_url(candidate_id)
-            resources = self.sync_paginated(url)
-
+            try:
+                resources = self.sync_paginated(url)
+            except RuntimeError as e:
+                # There's a bug in the Lever API where a missing resume will result
+                # in a ResourceNotFound error instead of returning an empty response
+                if "ResourceNotFound" in str(e):
+                    LOGGER.info("Candidate %s does not have resumes", candidate_id)
+                else:
+                    raise
 
 class OpportunityResumesStream(BaseStream):
     API_METHOD = "GET"
@@ -55,4 +62,12 @@ class OpportunityResumesStream(BaseStream):
             )
             opportunity_id = opportunity["id"]
             url = self.get_url(opportunity_id)
-            resources = self.sync_paginated(url)
+            try:
+                resources = self.sync_paginated(url)
+            except RuntimeError as e:
+                # There's a bug in the Lever API where a missing resume will result
+                # in a ResourceNotFound error instead of returning an empty response
+                if "ResourceNotFound" in str(e):
+                    LOGGER.info("Opportunity %s does not have resumes", opportunity_id)
+                else:
+                    raise


### PR DESCRIPTION
# Description of change
There's a bug in the Lever API where trying to fetch a resume from a candidate/opportunity without a resume will result in the following error:
```
{"code": "ResourceNotFound", "message": "Sorry, this candidate does not exist"}
```

In order to work around this, we catch the exception and search for the `ResourceNotFound` text in the error. If present, we simply log that the resume was not found and continue. Otherwise we re-raise the exception.

# Rollback steps
 - revert this branch
