### PR TITLE
Move child streams into opportunity's sync

### DIFF
--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -3,15 +3,77 @@
 import singer
 
 import tap_framework
+from tap_framework.streams import is_selected
 
 from tap_lever.client import LeverClient
 from tap_lever.streams import AVAILABLE_STREAMS
+
 
 LOGGER = singer.get_logger()  # noqa
 
 
 class LeverRunner(tap_framework.Runner):
-    pass
+    def get_streams_to_replicate(self):
+        streams = []
+        opportunity_child_catalogs = {}
+
+        if not self.catalog:
+            return streams
+        for stream_catalog in self.catalog.streams:
+            if not is_selected(stream_catalog):
+                LOGGER.info("'{}' is not marked selected, skipping."
+                            .format(stream_catalog.stream))
+                continue
+
+            for available_stream in self.available_streams:
+                if available_stream.matches_catalog(stream_catalog):
+                    if not available_stream.requirements_met(self.catalog):
+                        raise RuntimeError(
+                            "{} requires that that the following are "
+                            "selected: {}"
+                            .format(stream_catalog.stream,
+                                    ','.join(available_stream.REQUIRES)))
+
+                    if available_stream.TABLE in {'opportunity_applications',
+                                                  'opportunity_offers',
+                                                  'opportunity_referrals',
+                                                  'opportunity_resumes'}:
+                        LOGGER.info('Will sync %s during the Opportunity stream sync', available_stream.TABLE)
+                        opportunity_child_catalogs[available_stream.TABLE] = stream_catalog
+                    else:
+                        to_add = available_stream(self.config, self.state, stream_catalog, self.client)
+
+                        streams.append(to_add)
+
+        return (streams, opportunity_child_catalogs)
+
+    def do_sync(self):
+        LOGGER.info("Starting sync.")
+
+        streams, opportunity_child_catalogs = self.get_streams_to_replicate()
+
+        LOGGER.info('Will sync: %s', ', '.join([stream.TABLE for stream in streams]))
+
+        for stream in streams:
+            try:
+                stream.state = self.state
+
+                if stream.TABLE == 'opportunities':
+                    stream.sync(opportunity_child_catalogs)
+                else:
+                    stream.sync()
+                self.state = stream.state
+            except OSError as e:
+                LOGGER.error(str(e))
+                exit(e.errno)
+
+            except Exception as e:
+                LOGGER.error(str(e))
+                LOGGER.error('Failed to sync endpoint {}, moving on!'
+                             .format(stream.TABLE))
+                raise e
+
+        save_state(self.state)
 
 
 @singer.utils.handle_top_exception(LOGGER)

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -55,24 +55,13 @@ class LeverRunner(tap_framework.Runner):
         LOGGER.info('Will sync: %s', ', '.join([stream.TABLE for stream in streams]))
 
         for stream in streams:
-            try:
-                stream.state = self.state
+            stream.state = self.state
 
-                if stream.TABLE == 'opportunities':
-                    stream.sync(opportunity_child_catalogs)
-                else:
-                    stream.sync()
-                self.state = stream.state
-            except OSError as e:
-                LOGGER.error(str(e))
-                exit(e.errno)
-
-            except Exception as e:
-                LOGGER.error(str(e))
-                LOGGER.error('Failed to sync endpoint {}, moving on!'
-                             .format(stream.TABLE))
-                raise e
-
+            if stream.TABLE == 'opportunities':
+                stream.sync(opportunity_child_catalogs)
+            else:
+                stream.sync()
+            self.state = stream.state
         save_state(self.state)
 
 

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -7,7 +7,7 @@ from tap_framework.streams import is_selected
 
 from tap_lever.client import LeverClient
 from tap_lever.streams import AVAILABLE_STREAMS
-
+from tap_lever.state import save_state
 
 LOGGER = singer.get_logger()  # noqa
 

--- a/tap_lever/streams/applications.py
+++ b/tap_lever/streams/applications.py
@@ -47,19 +47,7 @@ class OpportunityApplicationsStream(BaseStream):
         _path = self.path.format(opportunity_id=opportunity)
         return "https://api.lever.co/v1{}".format(_path)
 
-    def sync_data(self):
-        table = self.TABLE
-
-        opportunities = stream_cache.get("opportunities")
-        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
-
+    def sync_data(self, opportunity_id):
         params = self.get_params(_next=None)
-        for i, opportunity in enumerate(opportunities):
-            LOGGER.info(
-                "Fetching referrals for opportunity {} of {}".format(
-                    i + 1, len(opportunities)
-                )
-            )
-            opportunity_id = opportunity["id"]
-            url = self.get_url(opportunity_id)
-            resources = self.sync_paginated(url, params)
+        url = self.get_url(opportunity_id)
+        resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/offers.py
+++ b/tap_lever/streams/offers.py
@@ -43,17 +43,7 @@ class OpportunityOffersStream(BaseStream):
         _path = self.path.format(opportunity_id=opportunity)
         return "https://api.lever.co/v1{}".format(_path)
 
-    def sync_data(self):
-        opportunities = stream_cache.get("opportunities")
-        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
-
+    def sync_data(self, opportunity_id):
         params = self.get_params(_next=None)
-        for i, opportunity in enumerate(opportunities):
-            LOGGER.info(
-                "Fetching offers for opportunity {} of {}".format(
-                    i + 1, len(opportunities)
-                )
-            )
-            opportunity_id = opportunity["id"]
-            url = self.get_url(opportunity_id)
-            resources = self.sync_paginated(url, params)
+        url = self.get_url(opportunity_id)
+        resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/opportunities.py
+++ b/tap_lever/streams/opportunities.py
@@ -1,7 +1,8 @@
 import singer
 from tap_lever.streams import cache as stream_cache
 from tap_lever.streams.base import TimeRangeStream
-from tap_lever.state import get_last_record_value_for_table
+from tap_lever.state import incorporate, save_state, \
+    get_last_record_value_for_table
 from tap_lever.config import get_config_start_date
 from datetime import timedelta, datetime
 import pytz
@@ -46,33 +47,37 @@ class OpportunityStream(TimeRangeStream):
             for opportunity in data:
                 opportunity_id = opportunity['id']
 
-                OpportunityApplicationsStream(
-                    self.config,
-                    self.state,
-                    child_stream['opportunity_applications'],
-                    self.client
-                ).sync_data(opportunity_id)
+                if child_stream.get('opportunity_applications'):
+                    OpportunityApplicationsStream(
+                        self.config,
+                        self.state,
+                        child_stream['opportunity_applications'],
+                        self.client
+                    ).sync_data(opportunity_id)
 
-                OpportunityOffersStream(
-                    self.config,
-                    self.state,
-                    child_stream['opportunity_offers'],
-                    self.client
-                ).sync_data(opportunity_id)
+                if child_stream.get('opportunity_offers'):
+                    OpportunityOffersStream(
+                        self.config,
+                        self.state,
+                        child_stream['opportunity_offers'],
+                        self.client
+                    ).sync_data(opportunity_id)
 
-                OpportunityReferralsStream(
-                    self.config,
-                    self.state,
-                    child_stream['opportunity_referrals'],
-                    self.client
-                ).sync_data(opportunity_id)
+                if child_stream.get('opportunity_referrals'):
+                    OpportunityReferralsStream(
+                        self.config,
+                        self.state,
+                        child_stream['opportunity_referrals'],
+                        self.client
+                    ).sync_data(opportunity_id)
 
-                OpportunityResumesStream(
-                    self.config,
-                    self.state,
-                    child_stream['opportunity_resumes'],
-                    self.client
-                ).sync_data(opportunity_id)
+                if child_stream.get('opportunity_resumes'):
+                    OpportunityResumesStream(
+                        self.config,
+                        self.state,
+                        child_stream['opportunity_resumes'],
+                        self.client
+                    ).sync_data(opportunity_id)
             LOGGER.info('Finished Opportunity child stream syncs')
 
 
@@ -119,7 +124,7 @@ class OpportunityStream(TimeRangeStream):
         if date is None:
             date = get_config_start_date(self.config)
 
-        interval = timedelta(days=7)
+        interval = timedelta(days=1)
 
         all_resources = []
         while date < datetime.now(pytz.utc):

--- a/tap_lever/streams/opportunities.py
+++ b/tap_lever/streams/opportunities.py
@@ -1,7 +1,14 @@
 import singer
 from tap_lever.streams import cache as stream_cache
 from tap_lever.streams.base import TimeRangeStream
-
+from tap_lever.state import get_last_record_value_for_table
+from tap_lever.config import get_config_start_date
+from datetime import timedelta, datetime
+import pytz
+from .applications import OpportunityApplicationsStream
+from .offers import OpportunityOffersStream
+from .referrals import OpportunityReferralsStream
+from .resumes import OpportunityResumesStream
 LOGGER = singer.get_logger()  # noqa
 
 
@@ -10,8 +17,118 @@ class OpportunityStream(TimeRangeStream):
     TABLE = "opportunities"
     KEY_PROPERTIES = ["id"]
 
-    CACHE_RESULTS = True
-
     @property
     def path(self):
         return "/opportunities"
+
+    def sync(self, child_streams=None):
+        LOGGER.info('Syncing stream {} with {}'
+                    .format(self.catalog.tap_stream_id,
+                            self.__class__.__name__))
+
+        self.write_schema()
+
+        return self.sync_data(child_streams)
+
+    def sync_paginated(self, url, params=None, child_stream=None):
+        table = self.TABLE
+        _next = True
+        page = 1
+
+        all_resources = []
+        transformer = singer.Transformer()
+        while _next is not None:
+            result = self.client.make_request(url, self.API_METHOD, params=params)
+            _next = result.get('next')
+            data = self.get_stream_data(result['data'], transformer)
+
+            LOGGER.info('Starting Opportunity child stream syncs')
+            for opportunity in data:
+                opportunity_id = opportunity['id']
+
+                OpportunityApplicationsStream(
+                    self.config,
+                    self.state,
+                    child_stream['opportunity_applications'],
+                    self.client
+                ).sync_data(opportunity_id)
+
+                OpportunityOffersStream(
+                    self.config,
+                    self.state,
+                    child_stream['opportunity_offers'],
+                    self.client
+                ).sync_data(opportunity_id)
+
+                OpportunityReferralsStream(
+                    self.config,
+                    self.state,
+                    child_stream['opportunity_referrals'],
+                    self.client
+                ).sync_data(opportunity_id)
+
+                OpportunityResumesStream(
+                    self.config,
+                    self.state,
+                    child_stream['opportunity_resumes'],
+                    self.client
+                ).sync_data(opportunity_id)
+            LOGGER.info('Finished Opportunity child stream syncs')
+
+
+            with singer.metrics.record_counter(endpoint=table) as counter:
+                singer.write_records(table, data)
+                counter.increment(len(data))
+                all_resources.extend(data)
+
+            if _next:
+                params['offset'] = _next
+
+            LOGGER.info('Synced page {} for {}'.format(page, self.TABLE))
+            page += 1
+        return all_resources
+
+    def sync_data_for_period(self, date, interval, child_stream=None):
+        table = self.TABLE
+
+        updated_after = date
+        updated_before = updated_after + interval
+
+        LOGGER.info(
+            'Syncing data from {} to {}'.format(
+                updated_after.isoformat(),
+                updated_before.isoformat()))
+
+        params = self.get_params(updated_after, updated_before)
+        url = self.get_url()
+        res = self.sync_paginated(url, params, child_stream)
+
+        self.state = incorporate(self.state,
+                                 table,
+                                 self.RANGE_FIELD,
+                                 date.isoformat())
+
+        save_state(self.state)
+        return res
+
+    def sync_data(self, child_stream=None):
+        table = self.TABLE
+
+        date = get_last_record_value_for_table(self.state, table)
+
+        if date is None:
+            date = get_config_start_date(self.config)
+
+        interval = timedelta(days=7)
+
+        all_resources = []
+        while date < datetime.now(pytz.utc):
+            res = self.sync_data_for_period(date, interval, child_stream)
+            all_resources.extend(res)
+            date = date + interval
+
+        if self.CACHE_RESULTS:
+            stream_cache.add(table, all_resources)
+            LOGGER.info('Added {} {}s to cache'.format(len(all_resources), table))
+
+        return self.state

--- a/tap_lever/streams/referrals.py
+++ b/tap_lever/streams/referrals.py
@@ -47,19 +47,7 @@ class OpportunityReferralsStream(BaseStream):
         _path = self.path.format(opportunity_id=opportunity)
         return "https://api.lever.co/v1{}".format(_path)
 
-    def sync_data(self):
-        table = self.TABLE
-
-        opportunities = stream_cache.get("opportunities")
-        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
-
+    def sync_data(self, opportunity_id):
         params = self.get_params(_next=None)
-        for i, opportunity in enumerate(opportunities):
-            LOGGER.info(
-                "Fetching referrals for opportunity {} of {}".format(
-                    i + 1, len(opportunities)
-                )
-            )
-            opportunity_id = opportunity["id"]
-            url = self.get_url(opportunity_id)
-            resources = self.sync_paginated(url, params)
+        url = self.get_url(opportunity_id)
+        resources = self.sync_paginated(url, params)

--- a/tap_lever/streams/resumes.py
+++ b/tap_lever/streams/resumes.py
@@ -50,24 +50,14 @@ class OpportunityResumesStream(BaseStream):
         _path = self.path.format(opportunity_id=opportunity)
         return "https://api.lever.co/v1{}".format(_path)
 
-    def sync_data(self):
-        opportunities = stream_cache.get("opportunities")
-        LOGGER.info("Found {} opportunities in cache".format(len(opportunities)))
-
-        for i, opportunity in enumerate(opportunities):
-            LOGGER.info(
-                "Fetching resumes for opportunity {} of {}".format(
-                    i + 1, len(opportunities)
-                )
-            )
-            opportunity_id = opportunity["id"]
-            url = self.get_url(opportunity_id)
-            try:
-                resources = self.sync_paginated(url)
-            except RuntimeError as e:
-                # There's a bug in the Lever API where a missing resume will result
-                # in a ResourceNotFound error instead of returning an empty response
-                if "ResourceNotFound" in str(e):
-                    LOGGER.info("Opportunity %s does not have resumes", opportunity_id)
-                else:
-                    raise
+    def sync_data(self, opportunity_id):
+        url = self.get_url(opportunity_id)
+        try:
+            resources = self.sync_paginated(url)
+        except RuntimeError as e:
+            # There's a bug in the Lever API where a missing resume will result
+            # in a ResourceNotFound error instead of returning an empty response
+            if "ResourceNotFound" in str(e):
+                LOGGER.info("Opportunity %s does not have resumes", opportunity_id)
+            else:
+                raise


### PR DESCRIPTION
# Description of change
This PR addresses the syncing of `Opportunities` and its substreams (`applications`, `refferals`, `offers`, and `resumes`). 

The previous strategy was to sync all of the `Opportunities` from the bookmarked date to now, save all of the records in memory, then when it was a substream's turn to sync grab the cache and sync `offers` for each `id` in the cache. 

The issue with this caching is that we only write state after each window of `Opportunities`, and never after a substream's sync. So when the tap fails (and it fails every now and then with a `'Remote end closed connection without response'`) we only get the substream data for opportunities we sync that run.

This PR moves the substream syncs into the sync function of `Opportunities`; for every 100 opportunities synced (which is the size of 1 `GET`), the tap will pause and go do each substream for the 100 `id`s. This way, even if the tap is interrupted, worst case scenario it resyncs the last window it was on.

This maybe could be reworked to write state after each page of opportunities.

# Manual QA steps
 - Ran the tap
 
# Risks
 - Low, the tap in its current state is already causing data discrepancies
 
# Rollback steps
 - revert this branch
