### PR TITLE
Bookmark on pagination parameters in opportunities stream

### DIFF
--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -35,7 +35,7 @@ class LeverClient:
 
         response_json = safe_json_parse(response)
         # NB: Observed - "Invalid offset token: Offset token is invalid for sort"
-        if response_json and "Invalid offset token" in response_json.get("message"):
+        if response_json and "Invalid offset token" in response_json.get("message", ""):
             raise OffsetInvalidException(response.text)
 
         if response.status_code != 200:

--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -4,6 +4,14 @@ import singer.metrics
 
 LOGGER = singer.get_logger()  # noqa
 
+class OffsetInvalidException(Exception):
+    pass
+
+def safe_json_parse(response):
+    try:
+        return response.json()
+    except:
+        return None
 
 class LeverClient:
 
@@ -24,6 +32,11 @@ class LeverClient:
             auth=(self.config['token'], ''),
             params=params,
             json=body)
+
+        response_json = safe_json_parse(response)
+        # NB: Observed - "Invalid offset token: Offset token is invalid for sort"
+        if response_json and "Invalid offset token" in response_json.get("message"):
+            raise OffsetInvalidException(response.text)
 
         if response.status_code != 200:
             raise RuntimeError(response.text)


### PR DESCRIPTION
On March 21, it seems that Lever made a change to the backing data, causing all opportunities to be updated. Because the tap wasn't storing a page bookmark, this causes it to "resync" opportunities and all child streams for that day, causing `N x 4` requests to be made, where `n` is the count of opportunities.

This can be prohibitive for large datasets, so this PR adds bookmarking on the pagination parameters for the Opportunities stream.