### PR TITLE
Transform datetimes to iso8601 strings

### DIFF
--- a/tap_lever/schemas/candidate_offers.json
+++ b/tap_lever/schemas/candidate_offers.json
@@ -5,7 +5,8 @@
       "type": "string"
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "creator": {
       "type": ["string", "null"]
@@ -43,13 +44,16 @@
           "type": ["string", "null"]
         },
         "firstOpenedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "lastOpenedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "signedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "signed": {
           "type": ["boolean", "null"]
@@ -57,10 +61,12 @@
       }
     },
     "approvedAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "sentAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_lever/schemas/candidate_referrals.json
+++ b/tap_lever/schemas/candidate_referrals.json
@@ -1,72 +1,74 @@
 {
-    "type": "object",
-    "properties": {
-        "id": {
-            "type": "string"
-        },
-        "type": {
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": ["null", "string"]
+    },
+    "text": {
+      "type": ["null", "string"]
+    },
+    "instructions": {
+      "type": ["null", "string"]
+    },
+    "fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
             "type": ["null", "string"]
-        },
-        "text": {
+          },
+          "text": {
             "type": ["null", "string"]
-        },
-        "instructions": {
+          },
+          "description": {
             "type": ["null", "string"]
-        },
-        "fields": {
-            "type": "array",
+          },
+          "required": {
+            "type": ["null", "boolean"]
+          },
+          "value": {
+            "type": ["null", "string"]
+          },
+          "prompt": {
+            "type": ["null", "string"]
+          },
+          "options": {
+            "type": ["array", "null"],
             "items": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": ["null", "string"]
-                    },
-                    "text": {
-                        "type": ["null", "string"]
-                    },
-                    "description": {
-                        "type": ["null", "string"]
-                    },
-                    "required": {
-                        "type": ["null", "boolean"]
-                    },
-                    "value": {
-                        "type": ["null", "string"]
-                    },
-                    "prompt": {
-                        "type": ["null", "string"]
-                    },
-                    "options": {
-                        "type": ["array", "null"],
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "text": {
-                                    "type": ["null", "string"]
-                                }
-                            }
-                        }
-                    }
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": ["null", "string"]
                 }
+              }
             }
-        },
-        "baseTemplateId": {
-            "type": ["null", "string"]
-        },
-        "user": {
-            "type": ["null", "string"]
-        },
-        "referrer": {
-            "type": ["null", "string"]
-        },
-        "stage": {
-            "type": ["null", "string"]
-        },
-        "createdAt": {
-            "type": ["null", "integer"]
-        },
-        "completedAt": {
-            "type": ["null", "integer"]
+          }
         }
+      }
+    },
+    "baseTemplateId": {
+      "type": ["null", "string"]
+    },
+    "user": {
+      "type": ["null", "string"]
+    },
+    "referrer": {
+      "type": ["null", "string"]
+    },
+    "stage": {
+      "type": ["null", "string"]
+    },
+    "createdAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "completedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
     }
+  }
 }

--- a/tap_lever/schemas/candidate_resumes.json
+++ b/tap_lever/schemas/candidate_resumes.json
@@ -5,7 +5,8 @@
       "type": "string"
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "file": {
       "type": ["object", "null"],

--- a/tap_lever/schemas/candidates.json
+++ b/tap_lever/schemas/candidates.json
@@ -53,7 +53,8 @@
       "type": ["null", "object"],
       "properties": {
         "archivedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "reason": {
           "type": ["string", "null"]
@@ -95,16 +96,20 @@
       "properties": {}
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "lastInteractionAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "lastAdvancedAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "snoozedUntil": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "urls": {
       "type": ["null", "object"],

--- a/tap_lever/schemas/opportunities.json
+++ b/tap_lever/schemas/opportunities.json
@@ -53,7 +53,8 @@
       "type": ["null", "object"],
       "properties": {
         "archivedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "reason": {
           "type": ["string", "null"]
@@ -91,16 +92,20 @@
       }
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "lastInteractionAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "lastAdvancedAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "snoozedUntil": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "urls": {
       "type": ["null", "object"],

--- a/tap_lever/schemas/opportunity_offers.json
+++ b/tap_lever/schemas/opportunity_offers.json
@@ -8,7 +8,8 @@
       "type": ["string", "null"]
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "creator": {
       "type": ["string", "null"]
@@ -46,13 +47,16 @@
           "type": ["string", "null"]
         },
         "firstOpenedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "lastOpenedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "signedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "signed": {
           "type": ["boolean", "null"]
@@ -64,16 +68,19 @@
               "type": ["string", "null"]
             },
             "lastOpenedAt": {
-              "type": ["integer", "null"]
+              "type": ["string", "null"],
+              "format": "date-time"
             },
             "role": {
               "type": ["string", "null"]
             },
             "signedAt": {
-              "type": ["integer", "null"]
+              "type": ["string", "null"],
+              "format": "date-time"
             },
             "firstOpenedAt": {
-              "type": ["integer", "null"]
+              "type": ["string", "null"],
+              "format": "date-time"
             },
             "signed": {
               "type": ["boolean", "null"]
@@ -86,10 +93,12 @@
       }
     },
     "approvedAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "sentAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "approved": {
       "type": ["boolean", "null"]
@@ -101,7 +110,8 @@
       "type": ["object", "null"],
       "properties": {
         "uploadedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "downloadUrl": {
           "type": ["string", "null"]
@@ -115,7 +125,8 @@
       "type": ["object", "null"],
       "properties": {
         "uploadedAt": {
-          "type": ["integer", "null"]
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "downloadUrl": {
           "type": ["string", "null"]

--- a/tap_lever/schemas/opportunity_referrals.json
+++ b/tap_lever/schemas/opportunity_referrals.json
@@ -1,72 +1,74 @@
 {
-    "type": "object",
-    "properties": {
-        "id": {
-            "type": "string"
-        },
-        "type": {
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": ["null", "string"]
+    },
+    "text": {
+      "type": ["null", "string"]
+    },
+    "instructions": {
+      "type": ["null", "string"]
+    },
+    "fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
             "type": ["null", "string"]
-        },
-        "text": {
+          },
+          "text": {
             "type": ["null", "string"]
-        },
-        "instructions": {
+          },
+          "description": {
             "type": ["null", "string"]
-        },
-        "fields": {
-            "type": "array",
+          },
+          "required": {
+            "type": ["null", "boolean"]
+          },
+          "value": {
+            "type": ["null", "string"]
+          },
+          "prompt": {
+            "type": ["null", "string"]
+          },
+          "options": {
+            "type": ["array", "null"],
             "items": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": ["null", "string"]
-                    },
-                    "text": {
-                        "type": ["null", "string"]
-                    },
-                    "description": {
-                        "type": ["null", "string"]
-                    },
-                    "required": {
-                        "type": ["null", "boolean"]
-                    },
-                    "value": {
-                        "type": ["null", "string"]
-                    },
-                    "prompt": {
-                        "type": ["null", "string"]
-                    },
-                    "options": {
-                        "type": ["array", "null"],
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "text": {
-                                    "type": ["null", "string"]
-                                }
-                            }
-                        }
-                    }
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": ["null", "string"]
                 }
+              }
             }
-        },
-        "baseTemplateId": {
-            "type": ["null", "string"]
-        },
-        "user": {
-            "type": ["null", "string"]
-        },
-        "referrer": {
-            "type": ["null", "string"]
-        },
-        "stage": {
-            "type": ["null", "string"]
-        },
-        "createdAt": {
-            "type": ["null", "integer"]
-        },
-        "completedAt": {
-            "type": ["null", "integer"]
+          }
         }
+      }
+    },
+    "baseTemplateId": {
+      "type": ["null", "string"]
+    },
+    "user": {
+      "type": ["null", "string"]
+    },
+    "referrer": {
+      "type": ["null", "string"]
+    },
+    "stage": {
+      "type": ["null", "string"]
+    },
+    "createdAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "completedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
     }
+  }
 }

--- a/tap_lever/schemas/opportunity_resumes.json
+++ b/tap_lever/schemas/opportunity_resumes.json
@@ -5,7 +5,8 @@
       "type": "string"
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "file": {
       "type": ["object", "null"],

--- a/tap_lever/schemas/postings.json
+++ b/tap_lever/schemas/postings.json
@@ -1,112 +1,114 @@
 {
-    "type": "object",
-    "properties": {
-        "id": {
-            "type": "string"
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "text": {
+      "type": ["string", "null"]
+    },
+    "createdAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "user": {
+      "type": ["string", "null"]
+    },
+    "owner": {
+      "type": ["string", "null"]
+    },
+    "hiringManager": {
+      "type": ["string", "null"]
+    },
+    "categories": {
+      "type": ["object", "null"],
+      "properties": {
+        "team": {
+          "type": ["string", "null"]
         },
-        "text": {
-            "type": ["string", "null"]
+        "department": {
+          "type": ["string", "null"]
         },
-        "createdAt": {
-            "type": ["integer", "null"]
+        "location": {
+          "type": ["string", "null"]
         },
-        "updatedAt": {
-            "type": ["integer", "null"]
+        "commitment": {
+          "type": ["string", "null"]
         },
-        "user": {
-            "type": ["string", "null"]
-        },
-        "owner": {
-            "type": ["string", "null"]
-        },
-        "hiringManager": {
-            "type": ["string", "null"]
-        },
-        "categories": {
-            "type": ["object", "null"],
-            "properties": {
-                "team": {
-                    "type": ["string", "null"]
-                },
-                "department": {
-                    "type": ["string", "null"]
-                },
-                "location": {
-                    "type": ["string", "null"]
-                },
-                "commitment": {
-                    "type": ["string", "null"]
-                },
-                "level": {
-                    "type": ["string", "null"]
-                }
-            }
-        },
-        "content": {
-            "type": ["object", "null"],
-            "properties": {
-                "description": {
-                    "type": ["string", "null"]
-                },
-                "lists": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "text": {
-                                "type": ["string", "null"]
-                            },
-                            "content": {
-                                "type": ["string", "null"]
-                            }
-                        }
-                    }
-                },
-                "closing": {
-                    "type": ["string", "null"]
-                },
-                "customQuestions": {
-                    "type": "array",
-                    "items": {
-                        "type": ["string", "null"]
-                    }
-                }
-            }
-        },
-        "tags": {
-            "type": ["array", "null"],
-            "items": {
-                "type": ["string", "null"]
-            }
-        },
-        "followers": {
-            "type": ["string", "null"]
-        },
-        "state": {
-            "type": ["string", "null"]
-        },
-        "distributionChannels": {
-            "type": ["null", "array"],
-            "items": {
-                "type": ["string", "null"]
-            }
-        },
-        "reqCode": {
-            "type": ["string", "null"]
-        },
-        "urls": {
-            "type": ["null", "object"],
-            "properties": {
-                "list": {
-                    "type": "string"
-                },
-                "show": {
-                    "type": "string"
-                },
-                "apply": {
-                    "type": "string"
-                }
-            }
+        "level": {
+          "type": ["string", "null"]
         }
+      }
+    },
+    "content": {
+      "type": ["object", "null"],
+      "properties": {
+        "description": {
+          "type": ["string", "null"]
+        },
+        "lists": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": ["string", "null"]
+              },
+              "content": {
+                "type": ["string", "null"]
+              }
+            }
+          }
+        },
+        "closing": {
+          "type": ["string", "null"]
+        },
+        "customQuestions": {
+          "type": "array",
+          "items": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "tags": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string", "null"]
+      }
+    },
+    "followers": {
+      "type": ["string", "null"]
+    },
+    "state": {
+      "type": ["string", "null"]
+    },
+    "distributionChannels": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["string", "null"]
+      }
+    },
+    "reqCode": {
+      "type": ["string", "null"]
+    },
+    "urls": {
+      "type": ["null", "object"],
+      "properties": {
+        "list": {
+          "type": "string"
+        },
+        "show": {
+          "type": "string"
+        },
+        "apply": {
+          "type": "string"
+        }
+      }
     }
+  }
 }

--- a/tap_lever/schemas/requisitions.json
+++ b/tap_lever/schemas/requisitions.json
@@ -14,7 +14,8 @@
             "type": "boolean"
         },
         "createdAt": {
-            "type": "integer"
+          "type": "string",
+          "format": "date-time"
         },
         "creator": {
             "type": ["string", "null"]

--- a/tap_lever/schemas/users.json
+++ b/tap_lever/schemas/users.json
@@ -14,10 +14,12 @@
       "type": ["string", "null"]
     },
     "createdAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "deactivatedAt": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "accessRole": {
       "type": ["string", "null"]

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -54,7 +54,7 @@ class BaseStream(base):
         page = 1
 
         all_resources = []
-        transformer = singer.Transformer()
+        transformer = singer.Transformer(singer.UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING)
         while _next is not None:
             result = self.client.make_request(url, self.API_METHOD, params=params)
             _next = result.get('next')
@@ -72,6 +72,7 @@ class BaseStream(base):
 
             LOGGER.info('Synced page {} for {}'.format(page, self.TABLE))
             page += 1
+        transformer.log_warning()
         return all_resources
 
     def get_stream_data(self, result, transformer):

--- a/tap_lever/streams/offers.py
+++ b/tap_lever/streams/offers.py
@@ -52,7 +52,7 @@ class OpportunityOffersStream(BaseStream):
         url = self.get_url(opportunity_id)
         resources = self.sync_paginated(url, params)
 
-        transformer = singer.Transformer()
+        transformer = singer.Transformer(singer.UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING)
         with singer.metrics.record_counter(endpoint=self.TABLE) as counter:
             for page in self.paginate(url, params, opportunity_id):
                 self.add_parent_id(page, opportunity_id)

--- a/tap_lever/streams/opportunities.py
+++ b/tap_lever/streams/opportunities.py
@@ -35,7 +35,7 @@ class OpportunityStream(TimeRangeStream):
     def sync_paginated(self, url, params=None, child_streams=None):
         table = self.TABLE
 
-        transformer = singer.Transformer()
+        transformer = singer.Transformer(singer.UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING)
         applications_stream = OpportunityApplicationsStream(self.config,
                                                             self.state,
                                                             child_streams.get('opportunity_applications'),
@@ -110,6 +110,8 @@ class OpportunityStream(TimeRangeStream):
                 save_state(self.state)
             else:
                 finished_paginating = True
+
+        transformer.log_warning()
         self.state = singer.bookmarks.clear_bookmark(self.state, table, "offset")
         self.state = singer.bookmarks.clear_bookmark(self.state, table, "next_page")
         save_state(self.state)


### PR DESCRIPTION
# Description of change
Transform datetimes to iso8601 strings

Involves changing the schema for datetime fields from `integer` -> `string` with a format of `date-time` and setting the correct format when initializing the transformer. 

# Manual QA steps
 - Ran on cloned connection and verified that all changed fields validate as date-times
 
# Risks
 - column splitting, but the single customer is going to drop and re-sync
 
# Rollback steps
 - revert this branch
