### PR TITLE
Fix opportunities bookmarking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,20 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-lever/lib/python3.5/site-packages/tap_lever/schemas/*.json
+      - run:
+          name: 'Integration Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-lever \
+                       --target=target-stitch \
+                       --orchestrator=stitch-orchestrator \
+                       --email=harrison+sandboxtest@stitchdata.com \
+                       --password=$SANDBOX_PASSWORD \
+                       --client-id=50 \
+                       tests
+
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,19 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-lever/lib/python3.5/site-packages/tap_lever/schemas/*.json
-      - run:
-          name: 'Integration Tests'
-          command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-lever \
-                       --target=target-stitch \
-                       --orchestrator=stitch-orchestrator \
-                       --email=harrison+sandboxtest@stitchdata.com \
-                       --password=$SANDBOX_PASSWORD \
-                       --client-id=50 \
-                       tests
+      # - run:
+      #     name: 'Integration Tests'
+      #     command: |
+      #       aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+      #       source dev_env.sh
+      #       source /usr/local/share/virtualenvs/tap-tester/bin/activate
+      #       run-test --tap=tap-lever \
+      #                  --target=target-stitch \
+      #                  --orchestrator=stitch-orchestrator \
+      #                  --email=harrison+sandboxtest@stitchdata.com \
+      #                  --password=$SANDBOX_PASSWORD \
+      #                  --client-id=50 \
+      #                  tests
 
 workflows:
   version: 2

--- a/tap_lever/streams/offers.py
+++ b/tap_lever/streams/offers.py
@@ -50,7 +50,6 @@ class OpportunityOffersStream(BaseStream):
     def sync_data(self, opportunity_id):
         params = self.get_params(_next=None)
         url = self.get_url(opportunity_id)
-        resources = self.sync_paginated(url, params)
 
         transformer = singer.Transformer(singer.UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING)
         with singer.metrics.record_counter(endpoint=self.TABLE) as counter:


### PR DESCRIPTION
# Description of change

The bookmarks for Opportunities were not being saved if the stream was interrupted in the middle of paginating a large data set. When we encounter a _next token, also update the date in the state.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
