### PR TITLE
feat: use exponential backoff on rate limit error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name='tap-lever',
       py_modules=['tap_lever'],
       install_requires=[
           'tap-framework==0.0.5',
+          'backoff'
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)

Currently testing out this tap and noticed when running it that I was getting a Runtime error saying it was going over the allowed rate limit. This commit uses what seems to be the common way to handle this exception in singer taps. Specifically this commit adds the backoff page as a dependency of this python package which catches the new RateLimitException exception class. The rate limit exception gets triggered in the method if the request json body includes a specific text string in the message.

# Manual QA steps

Fairly small change so I didn't do much manual testing. If that's a hard requirement here I can do more for this PR. I also don't see any examples of unit tests in the repo right now, so wasn't sure if that would help or what the expected structure for that would look like for this project.
 
# Risks

Not 100% sure. I don't know much about Singer, but one assumption is that a single instance of the Client class gets created and used to make requests. If that's not the case, then there will be multiple clients handling backoff instead of one meaning there is still a chance of a race condition to use the resources.
 
# Rollback steps
 - revert this branch
