### PR TITLE
PR 2 - [SAC-30610] - Metadata - keys in empty breadcrumb metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ singer-check-tap-data
 dist/
 get_catalog.py
 env/
+venv/
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
 ## 1.2.0
-  * Fix missing stream-level metadata at empty breadcrumb: use `get_standard_metadata()` to write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to `breadcrumb=[]` during discovery [#45](https://github.com/singer-io/tap-lever/pull/45)
-  * Upgrade `singer-python` to `6.8.0` [#45](https://github.com/singer-io/tap-lever/pull/45)
-  * Upgrade `requests` to `2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
+  * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
 
 ## 1.1.0
   * Libraries upgrade and tap-framework replacement [#38](https://github.com/singer-io/tap-lever/pull/38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+  * Fix missing stream-level metadata at empty breadcrumb: use `get_standard_metadata()` to write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to `breadcrumb=[]` during discovery [#45](https://github.com/singer-io/tap-lever/pull/45)
+  * Upgrade `singer-python` to `6.8.0` [#45](https://github.com/singer-io/tap-lever/pull/45)
+  * Upgrade `requests` to `2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
+
 ## 1.1.0
   * Libraries upgrade and tap-framework replacement [#38](https://github.com/singer-io/tap-lever/pull/38)
   * Backoff and retry implementation [#39](https://github.com/singer-io/tap-lever/pull/39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 1.2.0
-  * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
+  * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; write `parent-tap-stream-id` to empty breadcrumb metadata for child streams [#45](https://github.com/singer-io/tap-lever/pull/45)
+  * Upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
 
 ## 1.1.0
   * Libraries upgrade and tap-framework replacement [#38](https://github.com/singer-io/tap-lever/pull/38)

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,16 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-lever',
-      version='1.1.0',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Lever API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_lever'],
       install_requires=[
-          'singer-python==6.1.1',
+          'singer-python==6.8.0',
           'backoff==2.2.1',
-          'requests==2.32.4',
+          'requests==2.34.2',
       ],
       extras_require = {
         "dev": [

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -87,15 +87,6 @@ class BaseStream:
         )
         mdata = singer.metadata.to_map(mdata)
 
-        for field_name in schema.get('properties', {}).keys():
-            if field_name not in self.KEY_PROPERTIES and field_name not in (replication_keys or []):
-                mdata = singer.metadata.write(
-                    mdata,
-                    ('properties', field_name),
-                    'inclusion',
-                    'available'
-                )
-
         return [{
             'tap_stream_id': self.TABLE,
             'stream': self.TABLE,

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -86,6 +86,29 @@ class BaseStream:
             'available'
         )
 
+        mdata = singer.metadata.write(
+            mdata,
+            (),
+            'table-key-properties',
+            self.KEY_PROPERTIES
+        )
+
+        mdata = singer.metadata.write(
+            mdata,
+            (),
+            'forced-replication-method',
+            self.get_replication_method()
+        )
+
+        replication_keys = self.get_replication_keys()
+        if replication_keys:
+            mdata = singer.metadata.write(
+                mdata,
+                (),
+                'valid-replication-keys',
+                replication_keys
+            )
+
         for field_name, field_schema in schema.get('properties').items():
             inclusion = 'available'
 

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -77,50 +77,24 @@ class BaseStream:
 
     def generate_catalog(self):
         schema = self.get_schema()
-        mdata = singer.metadata.new()
-
-        mdata = singer.metadata.write(
-            mdata,
-            (),
-            'inclusion',
-            'available'
-        )
-
-        mdata = singer.metadata.write(
-            mdata,
-            (),
-            'table-key-properties',
-            self.KEY_PROPERTIES
-        )
-
-        mdata = singer.metadata.write(
-            mdata,
-            (),
-            'forced-replication-method',
-            self.get_replication_method()
-        )
-
         replication_keys = self.get_replication_keys()
-        if replication_keys:
-            mdata = singer.metadata.write(
-                mdata,
-                (),
-                'valid-replication-keys',
-                replication_keys
-            )
 
-        for field_name, field_schema in schema.get('properties').items():
-            inclusion = 'available'
+        mdata = singer.metadata.get_standard_metadata(
+            schema=schema,
+            key_properties=self.KEY_PROPERTIES,
+            valid_replication_keys=replication_keys or [],
+            replication_method=self.get_replication_method(),
+        )
+        mdata = singer.metadata.to_map(mdata)
 
-            if field_name in self.KEY_PROPERTIES:
-                inclusion = 'automatic'
-
-            mdata = singer.metadata.write(
-                mdata,
-                ('properties', field_name),
-                'inclusion',
-                inclusion
-            )
+        for field_name in schema.get('properties', {}).keys():
+            if field_name not in self.KEY_PROPERTIES and field_name not in (replication_keys or []):
+                mdata = singer.metadata.write(
+                    mdata,
+                    ('properties', field_name),
+                    'inclusion',
+                    'available'
+                )
 
         return [{
             'tap_stream_id': self.TABLE,
@@ -128,7 +102,7 @@ class BaseStream:
             'key_properties': self.KEY_PROPERTIES,
             'forced-replication-method': self.get_replication_method(),
             **({'parent-tap-stream-id': self.PARENT} if self.PARENT else {}),
-            'replication_keys': self.get_replication_keys(),
+            'replication_keys': replication_keys,
             'schema': self.get_schema(),
             'metadata': singer.metadata.to_list(mdata)
         }]

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -94,7 +94,7 @@ class BaseStream:
             'forced-replication-method': self.get_replication_method(),
             **({'parent-tap-stream-id': self.PARENT} if self.PARENT else {}),
             'replication_keys': replication_keys,
-            'schema': self.get_schema(),
+            'schema': schema,
             'metadata': singer.metadata.to_list(mdata)
         }]
 

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -87,12 +87,14 @@ class BaseStream:
         )
         mdata = singer.metadata.to_map(mdata)
 
+        if self.PARENT:
+            singer.metadata.write(mdata, (), 'parent-tap-stream-id', self.PARENT)
+
         return [{
             'tap_stream_id': self.TABLE,
             'stream': self.TABLE,
             'key_properties': self.KEY_PROPERTIES,
             'forced-replication-method': self.get_replication_method(),
-            **({'parent-tap-stream-id': self.PARENT} if self.PARENT else {}),
             'replication_keys': replication_keys,
             'schema': schema,
             'metadata': singer.metadata.to_list(mdata)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -49,3 +49,26 @@ class LeverDiscoveryTest(LeverBaseTest, unittest.TestCase):
                     actual_replication_keys,
                     expected_stream[self.REPLICATION_KEYS],
                 )
+
+                # Verify empty breadcrumb metadata contains required Singer spec keys
+                metadata_map = {
+                    tuple(e['breadcrumb']): e['metadata']
+                    for e in entry['metadata']
+                }
+                root_meta = metadata_map.get(())
+                self.assertIsNotNone(root_meta, f"{stream_name}: empty breadcrumb entry missing")
+                self.assertEqual(
+                    set(root_meta.get('table-key-properties', [])),
+                    expected_stream[self.PRIMARY_KEYS],
+                    f"{stream_name}: table-key-properties mismatch in metadata",
+                )
+                self.assertEqual(
+                    root_meta.get('forced-replication-method'),
+                    expected_stream[self.REPLICATION_METHOD],
+                    f"{stream_name}: forced-replication-method mismatch in metadata",
+                )
+                self.assertEqual(
+                    set(root_meta.get('valid-replication-keys', [])),
+                    expected_stream[self.REPLICATION_KEYS],
+                    f"{stream_name}: valid-replication-keys mismatch in metadata",
+                )

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -167,5 +167,10 @@ class TestLeverDiscovery(unittest.TestCase):
         stream = CandidateApplicationsStream(config, state, catalog, client)
         catalog_entry = stream.generate_catalog()[0]
 
-        self.assertIn('parent-tap-stream-id', catalog_entry)
-        self.assertEqual(catalog_entry['parent-tap-stream-id'], 'candidates')
+        self.assertNotIn('parent-tap-stream-id', catalog_entry)
+
+        metadata_map = {tuple(e['breadcrumb']): e['metadata'] for e in catalog_entry['metadata']}
+        root_meta = metadata_map.get(())
+        self.assertIsNotNone(root_meta)
+        self.assertIn('parent-tap-stream-id', root_meta)
+        self.assertEqual(root_meta['parent-tap-stream-id'], 'candidates')

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -99,6 +99,13 @@ class TestLeverDiscovery(unittest.TestCase):
         self.assertEqual(catalog_entry['tap_stream_id'], 'candidates')
         self.assertEqual(catalog_entry['key_properties'], ['id'])
 
+        # Verify the empty breadcrumb metadata contains table-level singer metadata
+        metadata_map = {tuple(entry['breadcrumb']): entry['metadata'] for entry in catalog_entry['metadata']}
+        root_meta = metadata_map.get(())
+        self.assertIsNotNone(root_meta, "Empty breadcrumb metadata entry is missing")
+        self.assertEqual(root_meta.get('table-key-properties'), ['id'])
+        self.assertEqual(root_meta.get('forced-replication-method'), 'FULL_TABLE')
+
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_generate_catalog_includes_parent_for_child_streams(self, mock_load_schema):
         """Verify generate_catalog includes parent-tap-stream-id for child streams."""

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -105,6 +105,48 @@ class TestLeverDiscovery(unittest.TestCase):
         self.assertIsNotNone(root_meta, "Empty breadcrumb metadata entry is missing")
         self.assertEqual(root_meta.get('table-key-properties'), ['id'])
         self.assertEqual(root_meta.get('forced-replication-method'), 'FULL_TABLE')
+        self.assertIn('valid-replication-keys', root_meta)
+        self.assertEqual(root_meta.get('valid-replication-keys'), [])
+        self.assertEqual(root_meta.get('inclusion'), 'available')
+
+    @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
+    def test_generate_catalog_empty_breadcrumb_all_required_keys(self, mock_load_schema):
+        """Verify all Singer spec keys are present at empty breadcrumb for every stream class."""
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"}
+            }
+        }
+        config = {"token": "test_token", "start_date": "2020-01-01T00:00:00Z"}
+        state = {}
+        catalog = MagicMock()
+        client = MagicMock()
+
+        required_root_keys = {'table-key-properties', 'forced-replication-method', 'valid-replication-keys', 'inclusion'}
+
+        for stream_class in AVAILABLE_STREAMS:
+            with self.subTest(stream=stream_class.TABLE):
+                stream = stream_class(config, state, catalog, client)
+                catalog_entry = stream.generate_catalog()[0]
+
+                metadata_map = {
+                    tuple(e['breadcrumb']): e['metadata']
+                    for e in catalog_entry['metadata']
+                }
+                root_meta = metadata_map.get(())
+
+                self.assertIsNotNone(root_meta, f"{stream_class.TABLE}: empty breadcrumb entry missing")
+                for key in required_root_keys:
+                    self.assertIn(key, root_meta, f"{stream_class.TABLE}: '{key}' missing from empty breadcrumb metadata")
+                self.assertEqual(
+                    root_meta['table-key-properties'], stream_class.KEY_PROPERTIES,
+                    f"{stream_class.TABLE}: table-key-properties mismatch"
+                )
+                self.assertEqual(
+                    root_meta['forced-replication-method'], stream_class.REPLICATION_METHOD,
+                    f"{stream_class.TABLE}: forced-replication-method mismatch"
+                )
 
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_generate_catalog_includes_parent_for_child_streams(self, mock_load_schema):


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30610
- keys at empty breadcrumb metadata level in catalog

# Manual QA steps
- [x] Discovery: Passes
- [ ] Sync: creds unavailable
- [x] Unit Tests: Passes
- [x] Integration Tests: Mock Passes
 
# Rollback steps
 - revert this branch
