### PR TITLE
PR 2 - [SAC-30940] - Unauthorized streams exclusion from catalog during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## 1.3.0
-  * Streams, the credentials cannot access (403) are now excluded from the catalog during discovery [#46](https://github.com/singer-io/tap-lever/pull/46)
-
 ## 1.2.0
   * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; write `parent-tap-stream-id` to empty breadcrumb metadata for child streams [#45](https://github.com/singer-io/tap-lever/pull/45)
   * Upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
+  * Streams, the credentials cannot access (403) are now excluded from the catalog during discovery [#46](https://github.com/singer-io/tap-lever/pull/46)
 
 ## 1.1.0
   * Libraries upgrade and tap-framework replacement [#38](https://github.com/singer-io/tap-lever/pull/38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.0
   * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; write `parent-tap-stream-id` to empty breadcrumb metadata for child streams [#45](https://github.com/singer-io/tap-lever/pull/45)
   * Upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)
-  * Streams, the credentials cannot access (403) are now excluded from the catalog during discovery [#46](https://github.com/singer-io/tap-lever/pull/46)
+  * Streams that the credentials cannot access (403) are now excluded from the catalog during discovery [#46](https://github.com/singer-io/tap-lever/pull/46)
 
 ## 1.1.0
   * Libraries upgrade and tap-framework replacement [#38](https://github.com/singer-io/tap-lever/pull/38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Streams, the credentials cannot access (403) are now excluded from the catalog during discovery [#46](https://github.com/singer-io/tap-lever/pull/46)
+
 ## 1.2.0
   * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; write `parent-tap-stream-id` to empty breadcrumb metadata for child streams [#45](https://github.com/singer-io/tap-lever/pull/45)
   * Upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-lever',
-      version='1.3.0',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Lever API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-lever',
-      version='1.2.0',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the Lever API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -4,7 +4,7 @@ import json
 import singer
 import sys
 
-from tap_lever.client import LeverClient
+from tap_lever.client import LeverClient, LeverForbiddenError
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.state import save_state
 from tap_lever.streams.base import is_stream_selected
@@ -24,9 +24,44 @@ class LeverRunner:
     def do_discover(self):
         LOGGER.info("Starting discovery.")
 
+        parent_streams = [s for s in self.available_streams if s.PARENT is None]
+
+        inaccessible_parents = set()
+        for stream_cls in parent_streams:
+            stream = stream_cls(self.config, {}, None, self.client)
+            if not stream.check_access():
+                inaccessible_parents.add(stream_cls.TABLE)
+
+        if len(inaccessible_parents) == len(parent_streams):
+            raise LeverForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+                "'read' access to any of the streams supported by the tap. Data collection "
+                "cannot be initiated due to lack of permissions."
+            )
+
+        if inaccessible_parents:
+            LOGGER.warning(
+                "The account credentials supplied do not have 'read' access to the following "
+                "stream(s): %s. These streams have been excluded from the catalog.",
+                ", ".join(sorted(inaccessible_parents)),
+            )
+
+        inaccessible = set(inaccessible_parents)
+        for stream_cls in self.available_streams:
+            if stream_cls.PARENT and stream_cls.PARENT in inaccessible:
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    stream_cls.TABLE,
+                    stream_cls.PARENT,
+                )
+                inaccessible.add(stream_cls.TABLE)
+
         catalog = []
         for available_stream in self.available_streams:
-            stream = available_stream(self.config, self.state, None, None)
+            if available_stream.TABLE in inaccessible:
+                continue
+
+            stream = available_stream(self.config, {}, None, self.client)
 
             for entry in stream.generate_catalog():
                 replication_method = entry.get("replication_method")

--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -20,6 +20,10 @@ class OffsetInvalidException(Exception):
     pass
 
 
+class LeverForbiddenError(Exception):
+    pass
+
+
 class LeverClient:
 
     MAX_TRIES = 5
@@ -65,6 +69,8 @@ class LeverClient:
             raise Server5xxError(msg)
         elif response.status_code == 429:
             raise Server429Error('Rate limit exceeded')
+        elif response.status_code == 403:
+            raise LeverForbiddenError(response.text)
         elif response.status_code != 200:
             raise RuntimeError(response.text)
 

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -115,6 +115,26 @@ class BaseStream:
 
         return self.sync_data()
 
+    def check_access(self) -> bool:
+        """
+        Probe this stream for read access.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True since access is governed by the parent.
+        """
+        from tap_lever.client import LeverForbiddenError
+        if self.PARENT:
+            return True
+        url = self.get_url()
+        try:
+            self.client.make_request(url, self.API_METHOD, params={"limit": 1})
+            return True
+        except LeverForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission, excluding from catalog.",
+                self.TABLE,
+            )
+            return False
+
     def get_url(self):
         return 'https://api.lever.co/v1{}'.format(self.path)
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tap_lever.client import LeverForbiddenError
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.streams.applications import CandidateApplicationsStream, OpportunityApplicationsStream
 from tap_lever.streams.candidates import CandidateStream
@@ -9,6 +10,9 @@ from tap_lever.streams.opportunities import OpportunityStream
 from tap_lever.streams.offers import CandidateOffersStream, OpportunityOffersStream
 from tap_lever.streams.referrals import CandidateReferralsStream, OpportunityReferralsStream
 from tap_lever.streams.resumes import CandidateResumesStream, OpportunityResumesStream
+from tap_lever.streams.users import UsersStream
+from tap_lever.streams.postings import PostingsStream
+from tap_lever.__init__ import LeverRunner
 
 
 class TestLeverDiscovery(unittest.TestCase):
@@ -174,3 +178,63 @@ class TestLeverDiscovery(unittest.TestCase):
         self.assertIsNotNone(root_meta)
         self.assertIn('parent-tap-stream-id', root_meta)
         self.assertEqual(root_meta['parent-tap-stream-id'], 'candidates')
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Tests for BaseStream.check_access() and do_discover() exclusion logic."""
+
+    def _make_stream(self, stream_cls, client):
+        config = {"token": "test", "start_date": "2020-01-01T00:00:00Z"}
+        return stream_cls(config, {}, None, client)
+
+    def _make_runner(self, client):
+        args = MagicMock()
+        args.config = {"token": "test", "start_date": "2020-01-01T00:00:00Z"}
+        args.state = {}
+        args.catalog = None
+        return LeverRunner(args, client, AVAILABLE_STREAMS)
+
+    def test_check_access_returns_true_on_success(self):
+        client = MagicMock()
+        client.make_request.return_value = {"data": [], "next": None}
+        self.assertTrue(self._make_stream(UsersStream, client).check_access())
+
+    def test_check_access_returns_false_on_403(self):
+        client = MagicMock()
+        client.make_request.side_effect = LeverForbiddenError("Forbidden")
+        self.assertFalse(self._make_stream(UsersStream, client).check_access())
+
+    def test_check_access_child_stream_always_true(self):
+        client = MagicMock()
+        config = {"token": "test", "start_date": "2020-01-01T00:00:00Z"}
+        for stream_cls in AVAILABLE_STREAMS:
+            if stream_cls.PARENT is not None:
+                stream = stream_cls(config, {}, None, client)
+                self.assertTrue(stream.check_access(), msg=f"{stream_cls.TABLE} should always be True")
+        client.make_request.assert_not_called()
+
+    def test_discover_excludes_inaccessible_parent_and_its_children(self):
+        client = MagicMock()
+
+        def side_effect(url, method, params=None, body=None):
+            if "/candidates" in url and "/opportunities" not in url:
+                raise LeverForbiddenError("Forbidden")
+            return {"data": [], "next": None}
+
+        client.make_request.side_effect = side_effect
+        runner = self._make_runner(client)
+
+        with patch("json.dump") as mock_dump:
+            runner.do_discover()
+            stream_ids = {e["tap_stream_id"] for e in mock_dump.call_args[0][0]["streams"]}
+
+        for excluded in ("candidates", "candidate_applications", "candidate_offers",
+                         "candidate_referrals", "candidate_resumes"):
+            self.assertNotIn(excluded, stream_ids)
+
+    def test_discover_raises_when_all_parent_streams_inaccessible(self):
+        client = MagicMock()
+        client.make_request.side_effect = LeverForbiddenError("Forbidden")
+        with self.assertRaises(LeverForbiddenError):
+            self._make_runner(client).do_discover()
+

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -11,7 +11,6 @@ from tap_lever.streams.offers import CandidateOffersStream, OpportunityOffersStr
 from tap_lever.streams.referrals import CandidateReferralsStream, OpportunityReferralsStream
 from tap_lever.streams.resumes import CandidateResumesStream, OpportunityResumesStream
 from tap_lever.streams.users import UsersStream
-from tap_lever.streams.postings import PostingsStream
 from tap_lever.__init__ import LeverRunner
 
 


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30940
- Exclude unauthorized streams from catalog during discovery  


# Manual QA steps
 - [ ]  Discovery: Creds unavailable
 - [ ]  Sync: Creds unavailable
 - [x]  Unit Tests: Passes
 - [x]  Integration test: Mock Passes
 
# Rollback steps
 - revert this branch