### PR TITLE
PR 2 - [SAC-30940] - Unauthorized streams exclusion from catalog during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error [#46](https://github.com/singer-io/tap-lever/pull/46)
+  * Added `LeverForbiddenError` for HTTP 403 responses
+  * Added `check_access()` to `BaseStream`; child streams always return `True`
+  * Added unit tests for access-check and discovery filtering
+
 ## 1.2.0
   * Fix catalog discovery: write `table-key-properties`, `forced-replication-method`, and `valid-replication-keys` to empty breadcrumb metadata using `get_standard_metadata()`; write `parent-tap-stream-id` to empty breadcrumb metadata for child streams [#45](https://github.com/singer-io/tap-lever/pull/45)
   * Upgrade `singer-python==6.8.0`, `requests==2.34.2` [#45](https://github.com/singer-io/tap-lever/pull/45)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-lever',
-      version='1.2.0',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the Lever API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -4,7 +4,7 @@ import json
 import singer
 import sys
 
-from tap_lever.client import LeverClient
+from tap_lever.client import LeverClient, LeverForbiddenError
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.state import save_state
 from tap_lever.streams.base import is_stream_selected
@@ -24,8 +24,41 @@ class LeverRunner:
     def do_discover(self):
         LOGGER.info("Starting discovery.")
 
+        # Check read access for each stream; child streams always pass.
+        inaccessible_tables = set()
+        for available_stream in self.available_streams:
+            stream = available_stream(self.config, self.state, None, self.client)
+            if not stream.check_access():
+                inaccessible_tables.add(available_stream.TABLE)
+
+        # Fail fast if no parent stream is reachable.
+        accessible_parents = [
+            s for s in self.available_streams
+            if s.PARENT is None and s.TABLE not in inaccessible_tables
+        ]
+        if not accessible_parents:
+            raise LeverForbiddenError(
+                "HTTP-error-code: 403, Error: The credentials do not have "
+                "'read' access to any supported streams."
+            )
+
+        if inaccessible_tables:
+            LOGGER.warning(
+                "No 'read' access to stream(s): %s. Excluded from catalog.",
+                ", ".join(sorted(inaccessible_tables)),
+            )
+
         catalog = []
         for available_stream in self.available_streams:
+            if available_stream.TABLE in inaccessible_tables:
+                continue
+            if available_stream.PARENT and available_stream.PARENT in inaccessible_tables:
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    available_stream.TABLE, available_stream.PARENT,
+                )
+                continue
+
             stream = available_stream(self.config, self.state, None, None)
 
             for entry in stream.generate_catalog():

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -5,7 +5,7 @@ import singer
 import sys
 
 from tap_lever.client import LeverClient, LeverUnauthorizedError
-from tap_lever.discovery import discover
+from tap_lever.discover import discover
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.state import save_state
 from tap_lever.streams.base import is_stream_selected

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -4,7 +4,7 @@ import json
 import singer
 import sys
 
-from tap_lever.client import LeverClient, LeverUnauthorizedError
+from tap_lever.client import LeverClient
 from tap_lever.discover import discover
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.state import save_state

--- a/tap_lever/__init__.py
+++ b/tap_lever/__init__.py
@@ -4,7 +4,8 @@ import json
 import singer
 import sys
 
-from tap_lever.client import LeverClient, LeverForbiddenError
+from tap_lever.client import LeverClient, LeverUnauthorizedError
+from tap_lever.discovery import discover
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.state import save_state
 from tap_lever.streams.base import is_stream_selected
@@ -23,60 +24,8 @@ class LeverRunner:
 
     def do_discover(self):
         LOGGER.info("Starting discovery.")
-
-        # Check read access for each stream; child streams always pass.
-        inaccessible_tables = set()
-        for available_stream in self.available_streams:
-            stream = available_stream(self.config, self.state, None, self.client)
-            if not stream.check_access():
-                inaccessible_tables.add(available_stream.TABLE)
-
-        # Fail fast if no parent stream is reachable.
-        accessible_parents = [
-            s for s in self.available_streams
-            if s.PARENT is None and s.TABLE not in inaccessible_tables
-        ]
-        if not accessible_parents:
-            raise LeverForbiddenError(
-                "HTTP-error-code: 403, Error: The credentials do not have "
-                "'read' access to any supported streams."
-            )
-
-        if inaccessible_tables:
-            LOGGER.warning(
-                "No 'read' access to stream(s): %s. Excluded from catalog.",
-                ", ".join(sorted(inaccessible_tables)),
-            )
-
-        catalog = []
-        for available_stream in self.available_streams:
-            if available_stream.TABLE in inaccessible_tables:
-                continue
-            if available_stream.PARENT and available_stream.PARENT in inaccessible_tables:
-                LOGGER.warning(
-                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
-                    available_stream.TABLE, available_stream.PARENT,
-                )
-                continue
-
-            stream = available_stream(self.config, self.state, None, None)
-
-            for entry in stream.generate_catalog():
-                replication_method = entry.get("replication_method")
-                replication_keys = entry.get("replication_keys", [])
-
-                if replication_method == "FULL_TABLE":
-                    entry.pop("replication_keys", None)
-                elif replication_method == "INCREMENTAL":
-                    if not replication_keys:
-                        raise ValueError(
-                            f"Stream '{entry.get('stream')}' is marked as INCREMENTAL "
-                            f"but has no replication_keys defined."
-                        )
-
-                catalog.append(entry)
-
-        json.dump({'streams': catalog}, sys.stdout, indent=4)
+        catalog = discover(self.client, self.config, self.state, self.available_streams)
+        json.dump(catalog, sys.stdout, indent=4)
 
     def get_streams_to_replicate(self):
         streams = []
@@ -134,6 +83,7 @@ class LeverRunner:
 def main():
     args = singer.utils.parse_args(required_config_keys=['token'])
     client = LeverClient(args.config)
+    client.verify_credentials()
     runner = LeverRunner(
         args, client, AVAILABLE_STREAMS)
 

--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -16,6 +16,10 @@ class Server429Error(Exception):
     pass
 
 
+class LeverForbiddenError(Exception):
+    pass
+
+
 class OffsetInvalidException(Exception):
     pass
 
@@ -65,6 +69,10 @@ class LeverClient:
             raise Server5xxError(msg)
         elif response.status_code == 429:
             raise Server429Error('Rate limit exceeded')
+        elif response.status_code == 403:
+            raise LeverForbiddenError(
+                f"HTTP-error-code: 403, Error: {response.text}"
+            )
         elif response.status_code != 200:
             raise RuntimeError(response.text)
 

--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -20,6 +20,10 @@ class LeverForbiddenError(Exception):
     pass
 
 
+class LeverUnauthorizedError(Exception):
+    pass
+
+
 class OffsetInvalidException(Exception):
     pass
 
@@ -30,6 +34,25 @@ class LeverClient:
 
     def __init__(self, config):
         self.config = config
+
+    def verify_credentials(self):
+        """Probe the API with the configured token and raise LeverUnauthorizedError
+        with a human-readable message if the credentials are invalid.
+        A 403 response is treated as valid credentials (just limited permissions),
+        so it is silently swallowed here; stream-level access is handled during discovery.
+        """
+        LOGGER.info("Verifying Lever API credentials.")
+        try:
+            self.make_request(
+                "https://api.lever.co/v1/users",
+                "GET",
+                params={"limit": 1},
+            )
+        except LeverForbiddenError:
+            # 403 means the token is authentic but lacks access to /users.
+            # Credentials are still valid; stream access is checked during discovery.
+            pass
+        LOGGER.info("Lever API credentials verified successfully.")
 
     # 429 Too Many Requests: Apply backoff strategy to handle rate limiting.
     # Lever API uses a token bucket algorithm to enforce rate limits, capping requests per second.
@@ -69,6 +92,11 @@ class LeverClient:
             raise Server5xxError(msg)
         elif response.status_code == 429:
             raise Server429Error('Rate limit exceeded')
+        elif response.status_code == 401:
+            raise LeverUnauthorizedError(
+                "HTTP-error-code: 401, Error: Invalid or missing API credentials. "
+                "Please verify the 'token' in your configuration."
+            )
         elif response.status_code == 403:
             raise LeverForbiddenError(
                 f"HTTP-error-code: 403, Error: {response.text}"

--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -39,9 +39,10 @@ class LeverClient:
         """
         Verify that the configured API token is valid.
         Raises LeverUnauthorizedError if the token is rejected by the API.
-        All other errors (permission 403, server errors, network issues) are
-        swallowed — this method is a credentials-only check; stream-level
-        access is determined separately during discovery.
+        A permission-level 403 (LeverForbiddenError) is treated as valid credentials
+        (the token is authentic; stream access is checked during discovery).
+        Any other error (5xx, network) cannot confirm credentials — a warning is
+        logged and execution continues without claiming success.
         """
         LOGGER.info("Verifying Lever API credentials.")
         try:
@@ -52,10 +53,18 @@ class LeverClient:
             )
         except LeverUnauthorizedError:
             raise
-        except Exception:
-            # Any non-auth error (permission 403, 5xx, network) is irrelevant
-            # to credential validity — ignore and let discovery handle it.
+        except LeverForbiddenError:
+            # Token is valid but lacks access to /users specifically.
+            # Treat as authenticated; stream-level access is handled during discovery.
             pass
+        except Exception:
+            # Network/server errors don't indicate invalid credentials.
+            # Log a warning and continue without claiming verification succeeded.
+            LOGGER.warning(
+                "Could not verify Lever API credentials due to a transient error; "
+                "proceeding — authentication will be confirmed on the first API call."
+            )
+            return
         LOGGER.info("Lever API credentials verified successfully.")
 
     # 429 Too Many Requests: Apply backoff strategy to handle rate limiting.

--- a/tap_lever/client.py
+++ b/tap_lever/client.py
@@ -36,10 +36,12 @@ class LeverClient:
         self.config = config
 
     def verify_credentials(self):
-        """Probe the API with the configured token and raise LeverUnauthorizedError
-        with a human-readable message if the credentials are invalid.
-        A 403 response is treated as valid credentials (just limited permissions),
-        so it is silently swallowed here; stream-level access is handled during discovery.
+        """
+        Verify that the configured API token is valid.
+        Raises LeverUnauthorizedError if the token is rejected by the API.
+        All other errors (permission 403, server errors, network issues) are
+        swallowed — this method is a credentials-only check; stream-level
+        access is determined separately during discovery.
         """
         LOGGER.info("Verifying Lever API credentials.")
         try:
@@ -48,9 +50,11 @@ class LeverClient:
                 "GET",
                 params={"limit": 1},
             )
-        except LeverForbiddenError:
-            # 403 means the token is authentic but lacks access to /users.
-            # Credentials are still valid; stream access is checked during discovery.
+        except LeverUnauthorizedError:
+            raise
+        except Exception:
+            # Any non-auth error (permission 403, 5xx, network) is irrelevant
+            # to credential validity — ignore and let discovery handle it.
             pass
         LOGGER.info("Lever API credentials verified successfully.")
 
@@ -98,6 +102,14 @@ class LeverClient:
                 "Please verify the 'token' in your configuration."
             )
         elif response.status_code == 403:
+            # Lever returns 403 with code "NotAuthorized" when the API key itself is invalid.
+            # Distinguish this from a genuine permission-denied (stream-level access) 403.
+            if response_json and response_json.get("code") == "NotAuthorized":
+                raise LeverUnauthorizedError(
+                    f"HTTP-error-code: 403, Error: Invalid API credentials. "
+                    f"{response_json.get('message', '')} "
+                    f"Please verify the 'token' in your configuration."
+                )
             raise LeverForbiddenError(
                 f"HTTP-error-code: 403, Error: {response.text}"
             )

--- a/tap_lever/discover.py
+++ b/tap_lever/discover.py
@@ -11,28 +11,28 @@ def discover(client, config, state, available_streams):
     Inaccessible parent streams (and their children) are excluded.
     Raises LeverForbiddenError if no parent stream is accessible.
     """
-    inaccessible_tables = _get_inaccessible_tables(client, config, state, available_streams)
+    inaccessible_streams = _get_inaccessible_streams(client, config, state, available_streams)
 
-    accessible_parents = [
+    accessible_parents_streams = [
         s for s in available_streams
-        if s.PARENT is None and s.TABLE not in inaccessible_tables
+        if s.PARENT is None and s.TABLE not in inaccessible_streams
     ]
-    if not accessible_parents:
+    if not accessible_parents_streams:
         raise LeverForbiddenError(
             "HTTP-error-code: 403, Error: The credentials do not have "
             "'read' access to any supported streams."
         )
 
-    if inaccessible_tables:
+    if inaccessible_streams:
         LOGGER.warning(
             "No 'read' access to stream(s): %s. Excluded from catalog.",
-            ", ".join(sorted(inaccessible_tables)),
+            ", ".join(sorted(inaccessible_streams)),
         )
 
-    return {"streams": _build_catalog_entries(config, state, available_streams, inaccessible_tables)}
+    return {"streams": _build_catalog_entries(config, state, available_streams, inaccessible_streams)}
 
 
-def _get_inaccessible_tables(client, config, state, available_streams):
+def _get_inaccessible_streams(client, config, state, available_streams):
     inaccessible = set()
     for stream_cls in available_streams:
         stream = stream_cls(config, state, None, client)
@@ -41,12 +41,12 @@ def _get_inaccessible_tables(client, config, state, available_streams):
     return inaccessible
 
 
-def _build_catalog_entries(config, state, available_streams, inaccessible_tables):
+def _build_catalog_entries(config, state, available_streams, inaccessible_streams):
     catalog = []
     for stream_cls in available_streams:
-        if stream_cls.TABLE in inaccessible_tables:
+        if stream_cls.TABLE in inaccessible_streams:
             continue
-        if stream_cls.PARENT and stream_cls.PARENT in inaccessible_tables:
+        if stream_cls.PARENT and stream_cls.PARENT in inaccessible_streams:
             LOGGER.warning(
                 "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
                 stream_cls.TABLE, stream_cls.PARENT,

--- a/tap_lever/discover.py
+++ b/tap_lever/discover.py
@@ -55,7 +55,7 @@ def _build_catalog_entries(config, state, available_streams, inaccessible_stream
 
         stream = stream_cls(config, state, None, None)
         for entry in stream.generate_catalog():
-            replication_method = entry.get("replication_method")
+            replication_method = entry.get("forced-replication-method")
             replication_keys = entry.get("replication_keys", [])
 
             if replication_method == "FULL_TABLE":

--- a/tap_lever/discover.py
+++ b/tap_lever/discover.py
@@ -23,10 +23,18 @@ def discover(client, config, state, available_streams):
             "'read' access to any supported streams."
         )
 
-    if inaccessible_streams:
+    # Include cascade-excluded children in the summary so the final warning
+    # covers every stream that will be absent from the catalog.
+    cascade_excluded = {
+        s.TABLE for s in available_streams
+        if s.PARENT and s.PARENT in inaccessible_streams
+    }
+    all_excluded = inaccessible_streams | cascade_excluded
+
+    if all_excluded:
         LOGGER.warning(
             "No 'read' access to stream(s): %s. Excluded from catalog.",
-            ", ".join(sorted(inaccessible_streams)),
+            ", ".join(sorted(all_excluded)),
         )
 
     return {"streams": _build_catalog_entries(config, state, available_streams, inaccessible_streams)}
@@ -47,10 +55,6 @@ def _build_catalog_entries(config, state, available_streams, inaccessible_stream
         if stream_cls.TABLE in inaccessible_streams:
             continue
         if stream_cls.PARENT and stream_cls.PARENT in inaccessible_streams:
-            LOGGER.warning(
-                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
-                stream_cls.TABLE, stream_cls.PARENT,
-            )
             continue
 
         stream = stream_cls(config, state, None, None)

--- a/tap_lever/discover.py
+++ b/tap_lever/discover.py
@@ -23,18 +23,16 @@ def discover(client, config, state, available_streams):
             "'read' access to any supported streams."
         )
 
-    # Include cascade-excluded children in the summary so the final warning
-    # covers every stream that will be absent from the catalog.
-    cascade_excluded = {
-        s.TABLE for s in available_streams
-        if s.PARENT and s.PARENT in inaccessible_streams
-    }
-    all_excluded = inaccessible_streams | cascade_excluded
-
-    if all_excluded:
+    if inaccessible_streams:
+        cascade_excluded = {
+            s.TABLE for s in available_streams
+            if s.PARENT and s.PARENT in inaccessible_streams
+        }
         LOGGER.warning(
-            "No 'read' access to stream(s): %s. Excluded from catalog.",
-            ", ".join(sorted(all_excluded)),
+            "No 'read' access to parent stream(s): [%s]."
+            " Cascade-excluded child stream(s): [%s]. Excluded from catalog.",
+            ", ".join(sorted(inaccessible_streams)),
+            ", ".join(sorted(cascade_excluded)) or "none",
         )
 
     return {"streams": _build_catalog_entries(config, state, available_streams, inaccessible_streams)}

--- a/tap_lever/discovery.py
+++ b/tap_lever/discovery.py
@@ -1,0 +1,70 @@
+import singer
+
+from tap_lever.client import LeverForbiddenError
+
+LOGGER = singer.get_logger()  # noqa
+
+
+def discover(client, config, state, available_streams):
+    """
+    Check stream access, build and return the catalog dict.
+    Inaccessible parent streams (and their children) are excluded.
+    Raises LeverForbiddenError if no parent stream is accessible.
+    """
+    inaccessible_tables = _get_inaccessible_tables(client, config, state, available_streams)
+
+    accessible_parents = [
+        s for s in available_streams
+        if s.PARENT is None and s.TABLE not in inaccessible_tables
+    ]
+    if not accessible_parents:
+        raise LeverForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have "
+            "'read' access to any supported streams."
+        )
+
+    if inaccessible_tables:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ", ".join(sorted(inaccessible_tables)),
+        )
+
+    return {"streams": _build_catalog_entries(config, state, available_streams, inaccessible_tables)}
+
+
+def _get_inaccessible_tables(client, config, state, available_streams):
+    inaccessible = set()
+    for stream_cls in available_streams:
+        stream = stream_cls(config, state, None, client)
+        if not stream.check_access():
+            inaccessible.add(stream_cls.TABLE)
+    return inaccessible
+
+
+def _build_catalog_entries(config, state, available_streams, inaccessible_tables):
+    catalog = []
+    for stream_cls in available_streams:
+        if stream_cls.TABLE in inaccessible_tables:
+            continue
+        if stream_cls.PARENT and stream_cls.PARENT in inaccessible_tables:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                stream_cls.TABLE, stream_cls.PARENT,
+            )
+            continue
+
+        stream = stream_cls(config, state, None, None)
+        for entry in stream.generate_catalog():
+            replication_method = entry.get("replication_method")
+            replication_keys = entry.get("replication_keys", [])
+
+            if replication_method == "FULL_TABLE":
+                entry.pop("replication_keys", None)
+            elif replication_method == "INCREMENTAL" and not replication_keys:
+                raise ValueError(
+                    f"Stream '{entry.get('stream')}' is marked as INCREMENTAL "
+                    f"but has no replication_keys defined."
+                )
+
+            catalog.append(entry)
+    return catalog

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -130,8 +130,8 @@ class BaseStream:
             return True
         except LeverForbiddenError as exc:
             LOGGER.warning(
-                "Permission Error: Stream '%s' - %s",
-                self.__class__.__name__,
+                "Excluding unauthorized stream '%s' from catalog. HTTP-Error-Message: '%s'",
+                self.TABLE,
                 exc,
             )
             return False

--- a/tap_lever/streams/base.py
+++ b/tap_lever/streams/base.py
@@ -13,6 +13,7 @@ from tap_lever.streams import cache as stream_cache
 from tap_lever.config import get_config_start_date
 from tap_lever.state import incorporate, save_state, \
     get_last_record_value_for_table
+from tap_lever.client import LeverForbiddenError
 
 
 LOGGER = singer.get_logger()
@@ -115,6 +116,25 @@ class BaseStream:
         self.write_schema()
 
         return self.sync_data()
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        if self.PARENT:
+            return True
+        try:
+            self.client.make_request(self.get_url(), self.API_METHOD, params={"limit": 1})
+            return True
+        except LeverForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.__class__.__name__,
+                exc,
+            )
+            return False
 
     def get_url(self):
         return 'https://api.lever.co/v1{}'.format(self.path)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,11 +1,14 @@
 """Unit tests for tap-lever stream discovery with mocked data."""
 import unittest
+from unittest.mock import MagicMock, patch
 
 try:
     from .base import LeverBaseTest
 except ImportError:
     from base import LeverBaseTest
 
+from tap_lever.client import LeverForbiddenError
+from tap_lever.discover import discover
 from tap_lever.streams import AVAILABLE_STREAMS
 
 
@@ -72,3 +75,108 @@ class LeverDiscoveryTest(LeverBaseTest, unittest.TestCase):
                     expected_stream[self.REPLICATION_KEYS],
                     f"{stream_name}: valid-replication-keys mismatch in metadata",
                 )
+
+
+class LeverDiscoveryExclusionTest(LeverBaseTest, unittest.TestCase):
+    """Integration tests for stream exclusion during discovery.
+
+    These tests exercise the full discover() pipeline with mocked check_access()
+    to verify that unauthorized streams (and their children) are excluded from
+    the returned catalog while authorized streams remain present.
+    """
+
+    def _run_discover(self, access_fn):
+        """Run discover() with a custom check_access side-effect and return catalog."""
+        client = MagicMock()
+        config = self.get_mock_config()
+        with patch("tap_lever.streams.base.BaseStream.check_access", access_fn):
+            return discover(client, config, {}, AVAILABLE_STREAMS)
+
+    # ── helpers ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _stream_ids(catalog):
+        return {s["tap_stream_id"] for s in catalog["streams"]}
+
+    # ── tests ──────────────────────────────────────────────────────────────────
+
+    def test_all_streams_accessible_catalog_is_complete(self):
+        """When every stream is accessible the catalog contains all streams."""
+        catalog = self._run_discover(lambda self: True)
+        stream_ids = self._stream_ids(catalog)
+        expected = {s.TABLE for s in AVAILABLE_STREAMS}
+        self.assertEqual(stream_ids, expected)
+
+    def test_inaccessible_parent_excluded_from_catalog(self):
+        """A parent stream blocked by 403 does not appear in the catalog."""
+        def access(self):
+            return self.TABLE != "candidates"
+
+        catalog = self._run_discover(access)
+        self.assertNotIn("candidates", self._stream_ids(catalog))
+
+    def test_inaccessible_parent_children_excluded_from_catalog(self):
+        """Children of a blocked parent stream are also excluded from the catalog."""
+        def access(self):
+            return self.TABLE != "candidates"
+
+        catalog = self._run_discover(access)
+        stream_ids = self._stream_ids(catalog)
+        candidate_children = {
+            s.TABLE for s in AVAILABLE_STREAMS if s.PARENT == "candidates"
+        }
+        for child in candidate_children:
+            self.assertNotIn(child, stream_ids, f"child '{child}' should be excluded")
+
+    def test_accessible_streams_unaffected_when_one_parent_blocked(self):
+        """Streams unrelated to the blocked parent still appear in the catalog."""
+        def access(self):
+            return self.TABLE != "candidates"
+
+        catalog = self._run_discover(access)
+        stream_ids = self._stream_ids(catalog)
+        # All non-candidate streams should still be present
+        unrelated = {
+            s.TABLE for s in AVAILABLE_STREAMS
+            if s.TABLE != "candidates" and s.PARENT != "candidates"
+        }
+        for table in unrelated:
+            self.assertIn(table, stream_ids, f"stream '{table}' should still be included")
+
+    def test_multiple_inaccessible_parents_all_excluded(self):
+        """Multiple blocked parent streams and all their children are excluded."""
+        blocked = {"candidates", "opportunities"}
+
+        def access(self):
+            return self.TABLE not in blocked
+
+        catalog = self._run_discover(access)
+        stream_ids = self._stream_ids(catalog)
+
+        blocked_with_children = blocked | {
+            s.TABLE for s in AVAILABLE_STREAMS if s.PARENT in blocked
+        }
+        for table in blocked_with_children:
+            self.assertNotIn(table, stream_ids, f"'{table}' should be excluded")
+
+    def test_all_inaccessible_raises_lever_forbidden_error(self):
+        """When no parent stream is accessible, LeverForbiddenError is raised."""
+        def access(self):
+            return bool(self.PARENT)  # children pass, all parents fail
+
+        with self.assertRaises(LeverForbiddenError):
+            self._run_discover(access)
+
+    def test_catalog_entries_have_required_fields_after_exclusion(self):
+        """Catalog entries for accessible streams are well-formed after exclusion."""
+        def access(self):
+            return self.TABLE != "candidates"
+
+        catalog = self._run_discover(access)
+        for entry in catalog["streams"]:
+            with self.subTest(stream=entry["tap_stream_id"]):
+                self.assertIn("tap_stream_id", entry)
+                self.assertIn("schema", entry)
+                self.assertIn("key_properties", entry)
+                self.assertIn("forced-replication-method", entry)
+                self.assertIn("metadata", entry)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -119,3 +119,24 @@ class TestVerifyCredentials(unittest.TestCase):
 
         client = LeverClient(default_config)
         client.verify_credentials()  # should not raise
+
+    @patch("tap_lever.client.requests.request")
+    def test_verify_credentials_does_not_claim_success_on_server_error(self, mock_request):
+        """verify_credentials does not raise and does not log success on a 5xx error.
+        A transient server error cannot confirm credentials; execution should continue
+        with a warning, not a success message.
+        """
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "Internal Server Error"
+        response.json.return_value = {}
+        mock_request.return_value = response
+
+        import logging
+        with self.assertLogs("root", level="WARNING") as log_ctx:
+            client = LeverClient(default_config)
+            client.verify_credentials()  # should not raise
+
+        log_output = "\n".join(log_ctx.output)
+        self.assertIn("transient error", log_output.lower())
+        self.assertNotIn("verified successfully", log_output.lower())

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tap_lever.client import LeverClient
+from tap_lever.client import LeverClient, LeverForbiddenError, LeverUnauthorizedError
 
 default_config = {
     "token": "dummy_api_token"
@@ -43,3 +43,63 @@ class TestClient(unittest.TestCase):
 
         call_kwargs = mock_request.call_args.kwargs
         self.assertEqual(call_kwargs["params"], params)
+
+
+class TestVerifyCredentials(unittest.TestCase):
+    @patch("tap_lever.client.requests.request")
+    def test_verify_credentials_succeeds_on_200(self, mock_request):
+        """verify_credentials does not raise when the API returns 200."""
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"data": [], "next": None}
+        mock_request.return_value = response
+
+        client = LeverClient(default_config)
+        client.verify_credentials()  # should not raise
+
+    @patch("tap_lever.client.requests.request")
+    def test_verify_credentials_raises_on_401(self, mock_request):
+        """verify_credentials raises LeverUnauthorizedError on HTTP 401."""
+        response = MagicMock()
+        response.status_code = 401
+        response.text = "Unauthorized"
+        response.json.return_value = {}
+        mock_request.return_value = response
+
+        client = LeverClient(default_config)
+        with self.assertRaises(LeverUnauthorizedError) as ctx:
+            client.verify_credentials()
+
+        self.assertIn("401", str(ctx.exception))
+        self.assertIn("credentials", str(ctx.exception).lower())
+
+    @patch("tap_lever.client.requests.request")
+    def test_verify_credentials_hits_users_endpoint(self, mock_request):
+        """verify_credentials probes the /users endpoint."""
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"data": [], "next": None}
+        mock_request.return_value = response
+
+        client = LeverClient(default_config)
+        client.verify_credentials()
+
+        # requests.request is called positionally: (method, url, ...)
+        call_args = mock_request.call_args
+        url = call_args.args[1] if call_args.args else call_args.kwargs.get("url", "")
+        self.assertIn("/users", url)
+
+    @patch("tap_lever.client.requests.request")
+    def test_verify_credentials_does_not_raise_on_403(self, mock_request):
+        """verify_credentials does not raise when /users returns 403.
+        Valid credentials with limited permissions should pass credential verification;
+        stream-level access is handled separately during discovery.
+        """
+        response = MagicMock()
+        response.status_code = 403
+        response.text = "Forbidden"
+        response.json.return_value = {}
+        mock_request.return_value = response
+
+        client = LeverClient(default_config)
+        client.verify_credentials()  # should not raise

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -74,6 +74,22 @@ class TestVerifyCredentials(unittest.TestCase):
         self.assertIn("credentials", str(ctx.exception).lower())
 
     @patch("tap_lever.client.requests.request")
+    def test_verify_credentials_raises_on_403_not_authorized(self, mock_request):
+        """verify_credentials raises LeverUnauthorizedError when Lever returns
+        403 with code='NotAuthorized' (invalid API key)."""
+        response = MagicMock()
+        response.status_code = 403
+        response.text = '{"code":"NotAuthorized","message":"Authentication incorrect."}'
+        response.json.return_value = {"code": "NotAuthorized", "message": "Authentication incorrect."}
+        mock_request.return_value = response
+
+        client = LeverClient(default_config)
+        with self.assertRaises(LeverUnauthorizedError) as ctx:
+            client.verify_credentials()
+
+        self.assertIn("credentials", str(ctx.exception).lower())
+
+    @patch("tap_lever.client.requests.request")
     def test_verify_credentials_hits_users_endpoint(self, mock_request):
         """verify_credentials probes the /users endpoint."""
         response = MagicMock()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -220,28 +220,20 @@ class TestCheckAccess(unittest.TestCase):
 
 
 class TestDoDiscoverAccessChecks(unittest.TestCase):
-    """Tests for LeverRunner.do_discover() access-check filtering."""
+    """Tests for discovery.discover() access-check filtering."""
 
-    def _make_runner(self, client):
-        from tap_lever import LeverRunner
-        args = MagicMock()
-        args.config = {"token": "test_token", "start_date": "2020-01-01T00:00:00Z"}
-        args.state = {}
-        args.catalog = None
-        return LeverRunner(args, client, AVAILABLE_STREAMS)
+    _config = {"token": "test_token", "start_date": "2020-01-01T00:00:00Z"}
+    _state = {}
 
     @patch('tap_lever.streams.base.BaseStream.check_access', return_value=True)
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_discover_all_accessible_builds_full_catalog(self, mock_schema, mock_access):
         """All streams accessible → catalog contains all streams."""
+        from tap_lever.discovery import discover
         mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
         client = MagicMock()
-        runner = self._make_runner(client)
 
-        import io, json
-        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
-            runner.do_discover()
-            catalog = json.loads(mock_out.getvalue())
+        catalog = discover(client, self._config, self._state, AVAILABLE_STREAMS)
 
         stream_ids = {s['tap_stream_id'] for s in catalog['streams']}
         self.assertEqual(len(stream_ids), len(AVAILABLE_STREAMS))
@@ -249,6 +241,7 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_discover_excludes_inaccessible_parent_and_its_children(self, mock_schema):
         """When candidates is inaccessible, it and its children are excluded."""
+        from tap_lever.discovery import discover
         mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
         client = MagicMock()
 
@@ -258,11 +251,7 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
             return self.TABLE != 'candidates'
 
         with patch('tap_lever.streams.base.BaseStream.check_access', access_side_effect):
-            runner = self._make_runner(client)
-            import io, json
-            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
-                runner.do_discover()
-                catalog = json.loads(mock_out.getvalue())
+            catalog = discover(client, self._config, self._state, AVAILABLE_STREAMS)
 
         stream_ids = {s['tap_stream_id'] for s in catalog['streams']}
         self.assertNotIn('candidates', stream_ids)
@@ -275,6 +264,7 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_discover_raises_when_no_parent_accessible(self, mock_schema):
         """If no parent stream is accessible, LeverForbiddenError is raised."""
+        from tap_lever.discovery import discover
         mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
         client = MagicMock()
 
@@ -282,6 +272,5 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
             return bool(self.PARENT)  # only children return True
 
         with patch('tap_lever.streams.base.BaseStream.check_access', no_access):
-            runner = self._make_runner(client)
             with self.assertRaises(LeverForbiddenError):
-                runner.do_discover()
+                discover(client, self._config, self._state, AVAILABLE_STREAMS)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -229,7 +229,7 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_discover_all_accessible_builds_full_catalog(self, mock_schema, mock_access):
         """All streams accessible → catalog contains all streams."""
-        from tap_lever.discovery import discover
+        from tap_lever.discover import discover
         mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
         client = MagicMock()
 
@@ -241,7 +241,7 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_discover_excludes_inaccessible_parent_and_its_children(self, mock_schema):
         """When candidates is inaccessible, it and its children are excluded."""
-        from tap_lever.discovery import discover
+        from tap_lever.discover import discover
         mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
         client = MagicMock()
 
@@ -264,7 +264,7 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
     @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
     def test_discover_raises_when_no_parent_accessible(self, mock_schema):
         """If no parent stream is accessible, LeverForbiddenError is raised."""
-        from tap_lever.discovery import discover
+        from tap_lever.discover import discover
         mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
         client = MagicMock()
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tap_lever.client import LeverForbiddenError
 from tap_lever.streams import AVAILABLE_STREAMS
 from tap_lever.streams.applications import CandidateApplicationsStream, OpportunityApplicationsStream
 from tap_lever.streams.candidates import CandidateStream
@@ -174,3 +175,113 @@ class TestLeverDiscovery(unittest.TestCase):
         self.assertIsNotNone(root_meta)
         self.assertIn('parent-tap-stream-id', root_meta)
         self.assertEqual(root_meta['parent-tap-stream-id'], 'candidates')
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Tests for BaseStream.check_access()."""
+
+    def _make_stream(self, stream_cls, client):
+        config = {"token": "test_token", "start_date": "2020-01-01T00:00:00Z"}
+        return stream_cls(config, {}, None, client)
+
+    def test_check_access_returns_true_when_request_succeeds(self):
+        """check_access() returns True when the API responds successfully."""
+        client = MagicMock()
+        client.make_request.return_value = {"data": [], "next": None}
+
+        stream = self._make_stream(CandidateStream, client)
+        self.assertTrue(stream.check_access())
+
+    def test_check_access_returns_false_on_forbidden(self):
+        """check_access() returns False when the API raises LeverForbiddenError."""
+        client = MagicMock()
+        client.make_request.side_effect = LeverForbiddenError("HTTP-error-code: 403")
+
+        stream = self._make_stream(CandidateStream, client)
+        self.assertFalse(stream.check_access())
+
+    def test_check_access_child_stream_always_returns_true(self):
+        """Child streams always return True regardless of API response."""
+        client = MagicMock()
+        client.make_request.side_effect = LeverForbiddenError("HTTP-error-code: 403")
+
+        stream = self._make_stream(CandidateApplicationsStream, client)
+        self.assertTrue(stream.check_access())
+        client.make_request.assert_not_called()
+
+    def test_check_access_opportunity_child_always_returns_true(self):
+        """Opportunity child streams return True without making a request."""
+        client = MagicMock()
+        client.make_request.side_effect = LeverForbiddenError("HTTP-error-code: 403")
+
+        stream = self._make_stream(OpportunityApplicationsStream, client)
+        self.assertTrue(stream.check_access())
+        client.make_request.assert_not_called()
+
+
+class TestDoDiscoverAccessChecks(unittest.TestCase):
+    """Tests for LeverRunner.do_discover() access-check filtering."""
+
+    def _make_runner(self, client):
+        from tap_lever import LeverRunner
+        args = MagicMock()
+        args.config = {"token": "test_token", "start_date": "2020-01-01T00:00:00Z"}
+        args.state = {}
+        args.catalog = None
+        return LeverRunner(args, client, AVAILABLE_STREAMS)
+
+    @patch('tap_lever.streams.base.BaseStream.check_access', return_value=True)
+    @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
+    def test_discover_all_accessible_builds_full_catalog(self, mock_schema, mock_access):
+        """All streams accessible → catalog contains all streams."""
+        mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
+        client = MagicMock()
+        runner = self._make_runner(client)
+
+        import io, json
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            runner.do_discover()
+            catalog = json.loads(mock_out.getvalue())
+
+        stream_ids = {s['tap_stream_id'] for s in catalog['streams']}
+        self.assertEqual(len(stream_ids), len(AVAILABLE_STREAMS))
+
+    @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
+    def test_discover_excludes_inaccessible_parent_and_its_children(self, mock_schema):
+        """When candidates is inaccessible, it and its children are excluded."""
+        mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
+        client = MagicMock()
+
+        def access_side_effect(self):
+            if self.PARENT:
+                return True
+            return self.TABLE != 'candidates'
+
+        with patch('tap_lever.streams.base.BaseStream.check_access', access_side_effect):
+            runner = self._make_runner(client)
+            import io, json
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                runner.do_discover()
+                catalog = json.loads(mock_out.getvalue())
+
+        stream_ids = {s['tap_stream_id'] for s in catalog['streams']}
+        self.assertNotIn('candidates', stream_ids)
+        self.assertNotIn('candidate_applications', stream_ids)
+        self.assertNotIn('candidate_offers', stream_ids)
+        self.assertNotIn('candidate_referrals', stream_ids)
+        self.assertNotIn('candidate_resumes', stream_ids)
+        self.assertIn('opportunities', stream_ids)
+
+    @patch('tap_lever.streams.base.BaseStream.load_schema_by_name')
+    def test_discover_raises_when_no_parent_accessible(self, mock_schema):
+        """If no parent stream is accessible, LeverForbiddenError is raised."""
+        mock_schema.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
+        client = MagicMock()
+
+        def no_access(self):
+            return bool(self.PARENT)  # only children return True
+
+        with patch('tap_lever.streams.base.BaseStream.check_access', no_access):
+            runner = self._make_runner(client)
+            with self.assertRaises(LeverForbiddenError):
+                runner.do_discover()


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30940
- Exclude unauthorized streams from catalog during discovery  


# Manual QA steps
 - [ ]  Discovery: Creds unavailable
 - [ ]  Sync: Creds unavailable
 - [x]  Unit Tests: Passes
 - [x]  Integration test: Mock Passes
 
# Rollback steps
 - revert this branch